### PR TITLE
export * as @yext/answers-core

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,6 @@ export function provideAnswersHeadless(config: HeadlessConfig): AnswersHeadless 
   return new AnswersHeadless(answersCore, stateManager, httpManager);
 }
 
+export * from '@yext/answers-core';
 export * from './utils/filter-creators';
 export { AnswersHeadless };


### PR DESCRIPTION
redux-toolkit also does this with redux.

Prior to this, for users of answers-headless, the recommendation was to rely on the @yext/answers-core
transitive dependency. Generally speaking this isn't advisable.
Relying on the transitive dep  also caused issues during local development of answers-headless and answers-headless-react.

If you try to export a duplicate non-TS identifier (so anything that isn't a type or interface) like `provideCore`,
you get a runtime error.
If you try to export a non-TS identifier that already has been exported as a type/interface, TS will yell at you.
If you try to export a type/interface that has also been exported from `export * from '@yext/answers-core'` the local one will always win, and no merging occurs.

To get around these annoying nuances, I considered explicitly exporting all answers-core models we use, instead of using `export *`.  However, as I was trying this out I noticed there were some intermediary interfaces like `DisplayableFacetOption` and `AppliedQueryFilter`, which we don't directly import in our source code, but the user would probably want to have access to. If we only export models directly used in src, we may miss out on these.
So, in that case we would basically have to manually `export *`, which seems a little strange to.

I tried using https://github.com/import-js/eslint-plugin-import to help detect duplicate exports, but from my testing it does not work with export *. After posting an issue it appears that it's not designed to https://github.com/import-js/eslint-plugin-import/issues/2281#event-5549287005

I tried testing this with api-extractor, and that also does not seem to give us any warning for this case.

J=SLAP-1664
TEST=manual

hooked up my local answers-headless to answers-headless-react
tested out exporting duplicate symbols