### PR TITLE
Update how static filter is handled in headless

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     }],
     '@typescript-eslint/semi': ['error'],
     '@typescript-eslint/type-annotation-spacing': ['error'],
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }]
   },
   overrides: [
     {

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -63,7 +63,7 @@ SOFTWARE.
 The following NPM packages may be included in this product:
 
  - @yext/answers-core@1.3.2
- - @yext/answers-headless@0.1.0-beta.1
+ - @yext/answers-headless@0.1.0-beta.2
 
 These packages each contain the following license and notice below:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -4,7 +4,6 @@ import {
   QuerySource,
   QuestionSubmissionRequest,
   Filter,
-  CombinedFilter,
   AutocompleteResponse,
   VerticalSearchResponse,
   UniversalSearchResponse,
@@ -26,6 +25,8 @@ import StateManager from './models/state-manager';
 import { Unsubscribe } from '@reduxjs/toolkit';
 import HttpManager from './http-manager';
 import answersUtilities from './answers-utilities';
+import { CombinedSelectableFilter, SelectableFilter } from './models/utils/selectablefilter';
+import { transformFiltersToCoreFormat } from './utils/transform-filters';
 
 export default class AnswersHeadless {
   readonly utilities: typeof answersUtilities;
@@ -66,7 +67,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('vertical/setOffset', offset);
   }
 
-  setFilter(filter: Filter | CombinedFilter | null): void {
+  setFilter(filter: Record<string, SelectableFilter | CombinedSelectableFilter> | null): void {
     this.stateManager.dispatchEvent('filters/setStatic', filter);
   }
 
@@ -194,7 +195,7 @@ export default class AnswersHeadless {
     const skipSpellCheck = !this.state.spellCheck.enabled;
     const sessionTrackingEnabled = this.state.sessionTracking.enabled;
     const sessionId = this.state.sessionTracking.sessionId;
-    const staticFilters = this.state.filters.static || undefined;
+    const staticFilters = transformFiltersToCoreFormat(this.state.filters.static) || undefined;
     const facets = this.state.filters?.facets;
     const limit = this.state.vertical.limit;
     const offset = this.state.vertical.offset;
@@ -296,6 +297,32 @@ export default class AnswersHeadless {
       facetOption
     };
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
+  }
+
+  addFilters(staticFiltersId: string, filters: Filter[]): void {
+    const payload = {
+      staticFiltersId,
+      filters
+    };
+    this.stateManager.dispatchEvent('filters/addFilters', payload);
+  }
+
+  selectFilterOption(filter: Filter, staticFiltersId?: string): void {
+    const payload = {
+      shouldSelect: true,
+      staticFiltersId,
+      filter
+    };
+    this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
+  }
+
+  unselectFilterOption(filter: Filter, staticFiltersId?: string): void {
+    const payload = {
+      shouldSelect: false,
+      staticFiltersId,
+      filter
+    };
+    this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }
 }
 

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -25,7 +25,7 @@ import StateManager from './models/state-manager';
 import { Unsubscribe } from '@reduxjs/toolkit';
 import HttpManager from './http-manager';
 import answersUtilities from './answers-utilities';
-import { CombinedSelectableFilter, SelectableFilter } from './models/utils/selectablefilter';
+import { SelectableFilter } from './models/utils/selectablefilter';
 import { transformFiltersToCoreFormat } from './utils/transform-filters';
 
 export default class AnswersHeadless {
@@ -67,7 +67,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('vertical/setOffset', offset);
   }
 
-  setFilter(filter: Record<string, SelectableFilter | CombinedSelectableFilter> | null): void {
+  setFilter(filter: Record<string, SelectableFilter[]> | null): void {
     this.stateManager.dispatchEvent('filters/setStatic', filter);
   }
 
@@ -299,7 +299,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  addFilters(filterSetId: string, filters: Filter[]): void {
+  addFilters(filterSetId: string, filters: SelectableFilter[]): void {
     const payload = {
       filterSetId,
       filters

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -296,11 +296,12 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  toggleFilterOption(filter: SelectableFilter, filterCollectionId: string): void {
+  toggleFilterOption(seletableFilter: SelectableFilter, filterCollectionId: string): void {
+    const { selected, ...filter } = seletableFilter;
     const payload = {
       filterCollectionId,
-      filter: filter.filter,
-      shouldSelect: filter.selected
+      filter: filter,
+      shouldSelect: selected
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -65,8 +65,8 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('vertical/setOffset', offset);
   }
 
-  setFilter(filter: Record<string, SelectableFilter[]> | null): void {
-    this.stateManager.dispatchEvent('filters/setStatic', filter);
+  setStaticFilters(filters: Record<string, SelectableFilter[]> | null): void {
+    this.stateManager.dispatchEvent('filters/setStatic', filters);
   }
 
   setFacets(facets: DisplayableFacet[]): void {
@@ -297,28 +297,11 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  addFilters(filterCollectionId: string, filters: SelectableFilter[]): void {
+  toggleFilterOption(filterCollectionId: string, filter: Filter, shouldSelect: boolean): void {
     const payload = {
       filterCollectionId,
-      filters
-    };
-    this.stateManager.dispatchEvent('filters/addFilters', payload);
-  }
-
-  selectFilterOption(filter: Filter, filterCollectionId?: string): void {
-    const payload = {
-      shouldSelect: true,
-      filterCollectionId,
-      filter
-    };
-    this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
-  }
-
-  unselectFilterOption(filter: Filter, filterCollectionId?: string): void {
-    const payload = {
-      shouldSelect: false,
-      filterCollectionId,
-      filter
+      filter,
+      shouldSelect
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -297,27 +297,27 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  addFilters(filterSetId: string, filters: SelectableFilter[]): void {
+  addFilters(filterCollectionId: string, filters: SelectableFilter[]): void {
     const payload = {
-      filterSetId,
+      filterCollectionId,
       filters
     };
     this.stateManager.dispatchEvent('filters/addFilters', payload);
   }
 
-  selectFilterOption(filter: Filter, filterSetId?: string): void {
+  selectFilterOption(filter: Filter, filterCollectionId?: string): void {
     const payload = {
       shouldSelect: true,
-      filterSetId,
+      filterCollectionId,
       filter
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }
 
-  unselectFilterOption(filter: Filter, filterSetId?: string): void {
+  unselectFilterOption(filter: Filter, filterCollectionId?: string): void {
     const payload = {
       shouldSelect: false,
-      filterSetId,
+      filterCollectionId,
       filter
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -296,14 +296,14 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  toggleFilterOption(seletableFilter: SelectableFilter, filterCollectionId: string): void {
+  setFilterOption(seletableFilter: SelectableFilter, filterCollectionId: string): void {
     const { selected, ...filter } = seletableFilter;
     const payload = {
       filterCollectionId,
       filter: filter,
       shouldSelect: selected
     };
-    this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
+    this.stateManager.dispatchEvent('filters/setFilterOption', payload);
   }
 }
 

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -3,7 +3,6 @@ import {
   QueryTrigger,
   QuerySource,
   QuestionSubmissionRequest,
-  Filter,
   AutocompleteResponse,
   VerticalSearchResponse,
   UniversalSearchResponse,

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -299,27 +299,27 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  addFilters(staticFiltersId: string, filters: Filter[]): void {
+  addFilters(filterSetId: string, filters: Filter[]): void {
     const payload = {
-      staticFiltersId,
+      filterSetId,
       filters
     };
     this.stateManager.dispatchEvent('filters/addFilters', payload);
   }
 
-  selectFilterOption(filter: Filter, staticFiltersId?: string): void {
+  selectFilterOption(filter: Filter, filterSetId?: string): void {
     const payload = {
       shouldSelect: true,
-      staticFiltersId,
+      filterSetId,
       filter
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }
 
-  unselectFilterOption(filter: Filter, staticFiltersId?: string): void {
+  unselectFilterOption(filter: Filter, filterSetId?: string): void {
     const payload = {
       shouldSelect: false,
-      staticFiltersId,
+      filterSetId,
       filter
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -297,11 +297,11 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  toggleFilterOption(filterCollectionId: string, filter: Filter, shouldSelect: boolean): void {
+  toggleFilterOption(filter: SelectableFilter, filterCollectionId: string): void {
     const payload = {
       filterCollectionId,
-      filter,
-      shouldSelect
+      filter: filter.filter,
+      shouldSelect: filter.selected
     };
     this.stateManager.dispatchEvent('filters/toggleFilterOption', payload);
   }

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -3,7 +3,7 @@ import { CombinedSelectableFilter, SelectableFilter } from '../utils/selectablef
 
 export interface FiltersState {
   static?: {
-   [staticFiltersId: string]: SelectableFilter | CombinedSelectableFilter | null;
+   [filterSetId: string]: SelectableFilter | CombinedSelectableFilter | null;
   }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -3,7 +3,7 @@ import { SelectableFilter } from '../utils/selectablefilter';
 
 export interface FiltersState {
   static?: {
-   [filterCollectionId: string]: SelectableFilter[] | null;
+   [filterCollectionId: string]: SelectableFilter[];
   }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -1,9 +1,9 @@
 import { DisplayableFacet, SortBy } from '@yext/answers-core';
-import { CombinedSelectableFilter, SelectableFilter } from '../utils/selectablefilter';
+import { SelectableFilter } from '../utils/selectablefilter';
 
 export interface FiltersState {
   static?: {
-   [filterSetId: string]: SelectableFilter | CombinedSelectableFilter | null;
+   [filterSetId: string]: SelectableFilter[] | null;
   }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -1,7 +1,10 @@
-import { CombinedFilter, DisplayableFacet, Filter, SortBy } from '@yext/answers-core';
+import { DisplayableFacet, SortBy } from '@yext/answers-core';
+import { CombinedSelectableFilter, SelectableFilter } from '../utils/selectablefilter';
 
 export interface FiltersState {
-  static?: Filter | CombinedFilter | null;
+  static?: {
+   [staticFiltersId: string]: SelectableFilter | CombinedSelectableFilter | null;
+  }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]
 }

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -1,11 +1,9 @@
 import { DisplayableFacet, SortBy } from '@yext/answers-core';
 import { SelectableFilter } from '../utils/selectablefilter';
 
-export type FilterCollection = SelectableFilter[];
-
 export interface FiltersState {
   static?: {
-   [filterCollectionId: string]: FilterCollection | null;
+   [filterCollectionId: string]: SelectableFilter[] | null;
   }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -1,9 +1,11 @@
 import { DisplayableFacet, SortBy } from '@yext/answers-core';
 import { SelectableFilter } from '../utils/selectablefilter';
 
+export type FilterCollection = SelectableFilter[];
+
 export interface FiltersState {
   static?: {
-   [filterSetId: string]: SelectableFilter[] | null;
+   [filterCollectionId: string]: FilterCollection | null;
   }
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]

--- a/src/models/utils/selectablefilter.ts
+++ b/src/models/utils/selectablefilter.ts
@@ -2,7 +2,7 @@ import { Filter, FilterCombinator } from '@yext/answers-core';
 
 export interface SelectableFilter {
   filter: Filter,
-  selectable: boolean
+  selected: boolean
 }
 
 export interface CombinedSelectableFilter {

--- a/src/models/utils/selectablefilter.ts
+++ b/src/models/utils/selectablefilter.ts
@@ -1,6 +1,5 @@
 import { Filter } from '@yext/answers-core';
 
-export interface SelectableFilter {
-  filter: Filter,
+export interface SelectableFilter extends Filter {
   selected: boolean
 }

--- a/src/models/utils/selectablefilter.ts
+++ b/src/models/utils/selectablefilter.ts
@@ -1,0 +1,11 @@
+import { Filter, FilterCombinator } from '@yext/answers-core';
+
+export interface SelectableFilter {
+  filter: Filter,
+  selectable: boolean
+}
+
+export interface CombinedSelectableFilter {
+  filters: (SelectableFilter | CombinedSelectableFilter)[];
+  combinator: FilterCombinator;
+}

--- a/src/models/utils/selectablefilter.ts
+++ b/src/models/utils/selectablefilter.ts
@@ -1,11 +1,6 @@
-import { Filter, FilterCombinator } from '@yext/answers-core';
+import { Filter } from '@yext/answers-core';
 
 export interface SelectableFilter {
   filter: Filter,
   selected: boolean
-}
-
-export interface CombinedSelectableFilter {
-  filters: (SelectableFilter | CombinedSelectableFilter)[];
-  combinator: FilterCombinator;
 }

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -81,8 +81,8 @@ const reducers = {
         ? filterCollection.push(selectedFilter)
         : state.static[filterCollectionId] = [selectedFilter];
     } else {
-      console.warn('Could not unselect a non-existing filter option in state'
-        + ` with following fields:\n${JSON.stringify(targetFilter)}.`);
+      console.warn('Could not unselect a non-existing filter option in state from filterCollectionId: '
+        + `'${filterCollectionId}' with the following fields:\n${JSON.stringify(targetFilter)}.`);
     }
   }
 };

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -87,13 +87,13 @@ export const filtersSlice = createSlice({
         storedFilters: SelectableFilter | CombinedSelectableFilter,
         targetFilter: Filter
       ) => {
-        if ('selectable' in storedFilters) {
+        if ('selected' in storedFilters) {
           const storedFilter = storedFilters.filter;
           if (storedFilter.fieldId === targetFilter.fieldId
             && storedFilter.matcher === targetFilter.matcher
             && storedFilter.value === targetFilter.value) {
             foundFilterOption = true;
-            storedFilters.selectable = shouldSelect;
+            storedFilters.selected = shouldSelect;
           }
         } else {
           storedFilters.filters.map(filters => handleFilterOptionSelection(filters, targetFilter));

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -59,8 +59,7 @@ const reducers = {
   },
   toggleFilterOption: (state: FiltersState, { payload }: PayloadAction<FilterPayload>) => {
     if (!state.static) {
-      console.warn('Trying to select a static filter option when no static filters exist.');
-      return;
+      state.static = {};
     }
     const { filterCollectionId, filter: targetFilter, shouldSelect } = payload;
     if (!state.static[filterCollectionId]) {

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -62,16 +62,12 @@ const reducers = {
       state.static = {};
     }
     const { filterCollectionId, filter: targetFilter, shouldSelect } = payload;
-    if (!state.static[filterCollectionId]) {
-      if (filterCollectionId && shouldSelect) {
-        state.static[filterCollectionId] = [];
-      } else {
-        console.warn(`invalid static filters id: ${filterCollectionId}`);
-        return;
-      }
+    if (!filterCollectionId) {
+      console.warn(`invalid static filters id: ${filterCollectionId}`);
+      return;
     }
     const filterCollection = state.static[filterCollectionId];
-    const foundFilter = filterCollection.find(storedSelectableFilter => {
+    const foundFilter = filterCollection?.find(storedSelectableFilter => {
       const storedFilter = storedSelectableFilter.filter;
       return storedFilter.fieldId === targetFilter.fieldId
         && storedFilter.matcher === targetFilter.matcher
@@ -80,10 +76,10 @@ const reducers = {
     if (foundFilter) {
       foundFilter.selected = shouldSelect;
     } else if (shouldSelect) {
-      filterCollection.push({
-        filter: targetFilter,
-        selected: shouldSelect
-      });
+      const selectedFilter = { filter: targetFilter, selected: shouldSelect };
+      filterCollection
+        ? filterCollection.push(selectedFilter)
+        : state.static[filterCollectionId] = [selectedFilter];
     } else {
       console.warn('Could not unselect a non-existing filter option in state'
         + ` with following fields:\n${JSON.stringify(targetFilter)}.`);

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -13,7 +13,7 @@ interface FacetPayload {
 }
 
 interface FilterPayload {
-  staticFiltersId?: string
+  filterSetId?: string
   filter: Filter
   shouldSelect: boolean
 }
@@ -40,13 +40,13 @@ export const filtersSlice = createSlice({
     },
     addFilters: (
       state: FiltersState,
-      action: PayloadAction<{staticFiltersId: string, filters: Filter[]}>
+      action: PayloadAction<{filterSetId: string, filters: Filter[]}>
     ) => {
-      const { staticFiltersId, filters } = action.payload;
+      const { filterSetId, filters } = action.payload;
       if (!state.static) {
         state.static = {};
       }
-      state.static[staticFiltersId] = transformFiltersToHeadlessFormat(filters);
+      state.static[filterSetId] = transformFiltersToHeadlessFormat(filters);
     },
     resetFacets: (state: FiltersState) => {
       state.facets?.forEach(facet => {
@@ -80,7 +80,7 @@ export const filtersSlice = createSlice({
         console.warn('Trying to select a static filter option when no static filters exist.');
         return;
       }
-      const { staticFiltersId, filter, shouldSelect } = payload;
+      const { filterSetId, filter, shouldSelect } = payload;
       let foundFilterOption = false;
 
       const handleFilterOptionSelection = (
@@ -100,11 +100,11 @@ export const filtersSlice = createSlice({
         }
       };
 
-      if (staticFiltersId && !state.static[staticFiltersId]) {
-        console.warn(`invalid static filters id: ${staticFiltersId}`);
+      if (filterSetId && !state.static[filterSetId]) {
+        console.warn(`invalid static filters id: ${filterSetId}`);
         return;
       }
-      const filtersInState = staticFiltersId && state.static[staticFiltersId];
+      const filtersInState = filterSetId && state.static[filterSetId];
       filtersInState
         ? handleFilterOptionSelection(filtersInState, filter)
         : Object.values(state.static)

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -12,7 +12,7 @@ interface FacetPayload {
 }
 
 interface FilterPayload {
-  filterSetId?: string
+  filterCollectionId?: string
   filter: Filter
   shouldSelect: boolean
 }
@@ -32,13 +32,13 @@ const reducers = {
   },
   addFilters: (
     state: FiltersState,
-    action: PayloadAction<{filterSetId: string, filters: SelectableFilter[]}>
+    action: PayloadAction<{filterCollectionId: string, filters: SelectableFilter[]}>
   ) => {
-    const { filterSetId, filters } = action.payload;
+    const { filterCollectionId, filters } = action.payload;
     if (!state.static) {
       state.static = {};
     }
-    state.static[filterSetId] = filters;
+    state.static[filterCollectionId] = filters;
   },
   resetFacets: (state: FiltersState) => {
     state.facets?.forEach(facet => {
@@ -72,10 +72,10 @@ const reducers = {
       console.warn('Trying to select a static filter option when no static filters exist.');
       return;
     }
-    const { filterSetId, filter, shouldSelect } = payload;
+    const { filterCollectionId, filter, shouldSelect } = payload;
 
-    if (filterSetId && !state.static[filterSetId]) {
-      console.warn(`invalid static filters id: ${filterSetId}`);
+    if (filterCollectionId && !state.static[filterCollectionId]) {
+      console.warn(`invalid static filters id: ${filterCollectionId}`);
       return;
     }
 
@@ -96,7 +96,7 @@ const reducers = {
       }
     };
 
-    const filtersInState = filterSetId && state.static[filterSetId];
+    const filtersInState = filterCollectionId && state.static[filterCollectionId];
     filtersInState
       ? handleFilterOptionSelection(filtersInState, filter)
       : Object.values(state.static)

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -1,12 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { CombinedFilter, Filter, FacetOption, DisplayableFacet, SortBy } from '@yext/answers-core';
+import { FacetOption, DisplayableFacet, SortBy, Filter } from '@yext/answers-core';
 import { FiltersState } from '../models/slices/filters';
+import { CombinedSelectableFilter, SelectableFilter } from '../models/utils/selectablefilter';
+import { transformFiltersToHeadlessFormat } from '../utils/transform-filters';
 
 const initialState: FiltersState = {};
 
 interface FacetPayload {
   fieldId: string
   facetOption: FacetOption
+  shouldSelect: boolean
+}
+
+interface FilterPayload {
+  staticFiltersId?: string
+  filter: Filter
   shouldSelect: boolean
 }
 
@@ -18,7 +26,10 @@ export const filtersSlice = createSlice({
   name: 'filters',
   initialState,
   reducers: {
-    setStatic: (state: FiltersState, action: PayloadAction<Filter|CombinedFilter|null>) => {
+    setStatic: (
+      state: FiltersState,
+      action: PayloadAction<Record<string, SelectableFilter | CombinedSelectableFilter>>
+    ) => {
       state.static = action.payload;
     },
     setFacets: (state: FiltersState, action: PayloadAction<DisplayableFacet[]>) => {
@@ -26,6 +37,16 @@ export const filtersSlice = createSlice({
     },
     setSortBys: (state: FiltersState, action: PayloadAction<SortBy[]>) => {
       state.sortBys = action.payload;
+    },
+    addFilters: (
+      state: FiltersState,
+      action: PayloadAction<{staticFiltersId: string, filters: Filter[]}>
+    ) => {
+      const { staticFiltersId, filters } = action.payload;
+      if (!state.static) {
+        state.static = {};
+      }
+      state.static[staticFiltersId] = transformFiltersToHeadlessFormat(filters);
     },
     resetFacets: (state: FiltersState) => {
       state.facets?.forEach(facet => {
@@ -54,8 +75,55 @@ export const filtersSlice = createSlice({
         });
       });
     },
+    toggleFilterOption: (state: FiltersState, { payload }: PayloadAction<FilterPayload>) => {
+      if (!state.static) {
+        console.warn('Trying to select a static filter option when no static filters exist.');
+        return;
+      }
+      const { staticFiltersId, filter, shouldSelect } = payload;
+      let foundFilterOption = false;
+
+      const handleFilterOptionSelection = (
+        storedFilters: SelectableFilter | CombinedSelectableFilter,
+        targetFilter: Filter
+      ) => {
+        if ('selectable' in storedFilters) {
+          const storedFilter = storedFilters.filter;
+          if (storedFilter.fieldId === targetFilter.fieldId
+            && storedFilter.matcher === targetFilter.matcher
+            && storedFilter.value === targetFilter.value) {
+            foundFilterOption = true;
+            storedFilters.selectable = shouldSelect;
+          }
+        } else {
+          storedFilters.filters.map(filters => handleFilterOptionSelection(filters, targetFilter));
+        }
+      };
+
+      if (staticFiltersId && !state.static[staticFiltersId]) {
+        console.warn(`invalid static filters id: ${staticFiltersId}`);
+        return;
+      }
+      const filtersInState = staticFiltersId && state.static[staticFiltersId];
+      filtersInState
+        ? handleFilterOptionSelection(filtersInState, filter)
+        : Object.values(state.static)
+          .forEach(storedFilters => storedFilters && handleFilterOptionSelection(storedFilters, filter));
+
+      if (!foundFilterOption) {
+        console.warn(
+          `Could not select a filter option with following fields:\n${JSON.stringify(filter)}.`);
+      }
+    }
   }
 });
 
-export const { setStatic, toggleFacetOption, setFacets, resetFacets } = filtersSlice.actions;
+export const {
+  setStatic,
+  addFilters,
+  setFacets,
+  resetFacets,
+  toggleFacetOption,
+  toggleFilterOption,
+} = filtersSlice.actions;
 export default filtersSlice.reducer;

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -57,7 +57,7 @@ const reducers = {
       });
     });
   },
-  toggleFilterOption: (state: FiltersState, { payload }: PayloadAction<FilterPayload>) => {
+  setFilterOption: (state: FiltersState, { payload }: PayloadAction<FilterPayload>) => {
     if (!state.static) {
       state.static = {};
     }

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -68,7 +68,7 @@ const reducers = {
     }
     const filterCollection = state.static[filterCollectionId];
     const foundFilter = filterCollection?.find(storedSelectableFilter => {
-      const storedFilter = storedSelectableFilter.filter;
+      const { selected:_, ...storedFilter } = storedSelectableFilter;
       return storedFilter.fieldId === targetFilter.fieldId
         && storedFilter.matcher === targetFilter.matcher
         && storedFilter.value === targetFilter.value;
@@ -76,7 +76,7 @@ const reducers = {
     if (foundFilter) {
       foundFilter.selected = shouldSelect;
     } else if (shouldSelect) {
-      const selectedFilter = { filter: targetFilter, selected: shouldSelect };
+      const selectedFilter = { ...targetFilter, selected: shouldSelect };
       filterCollection
         ? filterCollection.push(selectedFilter)
         : state.static[filterCollectionId] = [selectedFilter];

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -62,21 +62,22 @@ const reducers = {
       console.warn('Trying to select a static filter option when no static filters exist.');
       return;
     }
-
     const { filterCollectionId, filter: targetFilter, shouldSelect } = payload;
-    const filterCollection = state.static[filterCollectionId];
-    if (!filterCollection) {
-      console.warn(`invalid static filters id: ${filterCollectionId}`);
-      return;
+    if (!state.static[filterCollectionId]) {
+      if (filterCollectionId && shouldSelect) {
+        state.static[filterCollectionId] = [];
+      } else {
+        console.warn(`invalid static filters id: ${filterCollectionId}`);
+        return;
+      }
     }
-
+    const filterCollection = state.static[filterCollectionId];
     const foundFilter = filterCollection.find(storedSelectableFilter => {
       const storedFilter = storedSelectableFilter.filter;
       return storedFilter.fieldId === targetFilter.fieldId
         && storedFilter.matcher === targetFilter.matcher
         && storedFilter.value === targetFilter.value;
     });
-
     if (foundFilter) {
       foundFilter.selected = shouldSelect;
     } else if (shouldSelect) {

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -24,12 +24,14 @@ function transformAFilterSetToCoreFormat(
     return null;
   }
   if (filters.length === 1) {
-    return { ...filters[0].filter };
+    const { selected:_, ...filter } = filters[0];
+    return filter;
   }
   const groupedFilters: Record<string, Filter[]> = filters.reduce((groups, element) => {
-    groups[element.filter.fieldId]
-      ? groups[element.filter.fieldId].push({ ...element.filter })
-      : groups[element.filter.fieldId] = [{ ...element.filter }];
+    const { selected:_, ...filter } = element;
+    groups[element.fieldId]
+      ? groups[element.fieldId].push({ ...filter })
+      : groups[element.fieldId] = [{ ...filter }];
     return groups;
   }, {});
 

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -1,0 +1,89 @@
+import { CombinedFilter, Filter, FilterCombinator } from '@yext/answers-core';
+import { CombinedSelectableFilter, SelectableFilter } from '../models/utils/selectablefilter';
+
+
+function formatOrFilters(filters: Filter[]): SelectableFilter | CombinedSelectableFilter {
+  if (filters.length === 1) {
+    return {
+      filter: filters[0],
+      selectable: false
+    };
+  }
+  const selectableFilters = filters.map(filter => ({
+    filter: filter,
+    selectable: false
+  }));
+
+  return {
+    combinator: FilterCombinator.OR,
+    filters: selectableFilters
+  };
+}
+
+/**
+ * Convert a list of filters to nested filter structure use in Headless
+ */
+export function transformFiltersToHeadlessFormat(
+  filters: Filter[]
+): SelectableFilter | CombinedSelectableFilter | null {
+  if (!filters || filters.length === 0) {
+    return null;
+  }
+  if (filters.length === 1) {
+    return {
+      filter: filters[0],
+      selectable: false
+    };
+  }
+  const groupedFilters: Record<string, Filter[]> = filters.reduce((groups, element) => {
+    groups[element.fieldId]
+      ? groups[element.fieldId].push(element)
+      : groups[element.fieldId] = [element];
+    return groups;
+  }, {});
+
+  const groupedFilterLabels = Object.keys(groupedFilters);
+  if (groupedFilterLabels.length === 1) {
+    return formatOrFilters(groupedFilters[groupedFilterLabels[0]]);
+  }
+  return {
+    combinator: FilterCombinator.AND,
+    filters: Object.values(groupedFilters).map((filters: Filter[]) => formatOrFilters(filters))
+  };
+}
+
+/**
+ * Convert a map of filtersId to filters in nested structure use in Answers Headless
+ * to a single nested filter stucture use in Answers Core
+ */
+export function transformFiltersToCoreFormat(
+  filters: Record<string, SelectableFilter | CombinedSelectableFilter | null> | undefined
+): Filter | CombinedFilter | null {
+  if (!filters) {
+    return null;
+  }
+
+  const getCoreFormattedFilters = (
+    filter: SelectableFilter | CombinedSelectableFilter
+  ): Filter | CombinedFilter => {
+    if ('selectable' in filter) {
+      return { ...filter.filter };
+    }
+    return {
+      combinator: filter.combinator,
+      filters: filter.filters.map(filter => getCoreFormattedFilters(filter))
+    };
+  };
+
+  const coreFormattedFilters: (Filter | CombinedFilter)[] = [];
+  Object.values(filters).forEach(filter => {
+    filter && coreFormattedFilters.push(getCoreFormattedFilters(filter));
+  });
+  if (coreFormattedFilters.length === 1) {
+    return coreFormattedFilters[0];
+  }
+  return {
+    combinator: FilterCombinator.AND,
+    filters: coreFormattedFilters
+  };
+}

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -1,7 +1,10 @@
 import { CombinedFilter, Filter, FilterCombinator } from '@yext/answers-core';
 import { SelectableFilter } from '../models/utils/selectablefilter';
 
-function formatOrFilters(filters: Filter[]): Filter | CombinedFilter {
+/**
+ * Combine a given list of Filter using OR condition into a single CombinedFilter object
+ */
+function combineFiltersWithOR(filters: Filter[]): Filter | CombinedFilter {
   if (filters.length === 1) {
     return filters[0];
   }
@@ -32,11 +35,11 @@ function transformAFilterSetToCoreFormat(
 
   const groupedFilterLabels = Object.keys(groupedFilters);
   if (groupedFilterLabels.length === 1) {
-    return formatOrFilters(groupedFilters[groupedFilterLabels[0]]);
+    return combineFiltersWithOR(groupedFilters[groupedFilterLabels[0]]);
   }
   return {
     combinator: FilterCombinator.AND,
-    filters: Object.values(groupedFilters).map((filters: Filter[]) => formatOrFilters(filters))
+    filters: Object.values(groupedFilters).map((filters: Filter[]) => combineFiltersWithOR(filters))
   };
 }
 

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -6,12 +6,12 @@ function formatOrFilters(filters: Filter[]): SelectableFilter | CombinedSelectab
   if (filters.length === 1) {
     return {
       filter: filters[0],
-      selectable: false
+      selected: false
     };
   }
   const selectableFilters = filters.map(filter => ({
     filter: filter,
-    selectable: false
+    selected: false
   }));
 
   return {
@@ -32,7 +32,7 @@ export function transformFiltersToHeadlessFormat(
   if (filters.length === 1) {
     return {
       filter: filters[0],
-      selectable: false
+      selected: false
     };
   }
   const groupedFilters: Record<string, Filter[]> = filters.reduce((groups, element) => {
@@ -66,7 +66,7 @@ export function transformFiltersToCoreFormat(
   const getCoreFormattedFilters = (
     filter: SelectableFilter | CombinedSelectableFilter
   ): Filter | CombinedFilter => {
-    if ('selectable' in filter) {
+    if ('selected' in filter) {
       return { ...filter.filter };
     }
     return {

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -45,19 +45,17 @@ function transformAFilterSetToCoreFormat(
  * to a single nested filter stucture use in Answers Core
  */
 export function transformFiltersToCoreFormat(
-  filters: Record<string, SelectableFilter[] | null> | undefined
+  filters: Record<string, SelectableFilter[]> | null | undefined
 ): Filter | CombinedFilter | null {
   if (!filters) {
     return null;
   }
 
   const coreFormattedFilters: (Filter | CombinedFilter)[] = [];
-  Object.values(filters).forEach((filter: SelectableFilter[] | null) => {
-    if (filter) {
-      const selectedFilters = filter.filter(filter => filter.selected);
-      const transformedFilterSet = transformAFilterSetToCoreFormat(selectedFilters);
-      transformedFilterSet && coreFormattedFilters.push(transformedFilterSet);
-    }
+  Object.values(filters).forEach((filter: SelectableFilter[]) => {
+    const selectedFilters = filter.filter(filter => filter.selected);
+    const transformedFilterSet = transformAFilterSetToCoreFormat(selectedFilters);
+    transformedFilterSet && coreFormattedFilters.push(transformedFilterSet);
   });
 
   if (coreFormattedFilters.length === 0) {

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -48,15 +48,15 @@ function transformAFilterSetToCoreFormat(
  * to a single nested filter stucture use in Answers Core
  */
 export function transformFiltersToCoreFormat(
-  filters: Record<string, SelectableFilter[]> | null | undefined
+  filerCollections: Record<string, SelectableFilter[]> | null | undefined
 ): Filter | CombinedFilter | null {
-  if (!filters) {
+  if (!filerCollections) {
     return null;
   }
 
   const coreFormattedFilters: (Filter | CombinedFilter)[] = [];
-  Object.values(filters).forEach((filter: SelectableFilter[]) => {
-    const selectedFilters = filter.filter(filter => filter.selected);
+  Object.values(filerCollections).forEach((selectableFilters: SelectableFilter[]) => {
+    const selectedFilters = selectableFilters.filter(selectableFilter => selectableFilter.selected);
     const transformedFilterSet = transformAFilterSetToCoreFormat(selectedFilters);
     transformedFilterSet && coreFormattedFilters.push(transformedFilterSet);
   });

--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -2,7 +2,7 @@ import { CombinedFilter, Filter, FilterCombinator } from '@yext/answers-core';
 import { SelectableFilter } from '../models/utils/selectablefilter';
 
 /**
- * Combine a given list of Filter using OR condition into a single CombinedFilter object
+ * Combine a list of Filters using the logical OR operator into a CombinedFilter
  */
 function combineFiltersWithOR(filters: Filter[]): Filter | CombinedFilter {
   if (filters.length === 1) {
@@ -15,7 +15,7 @@ function combineFiltersWithOR(filters: Filter[]): Filter | CombinedFilter {
 }
 
 /**
- * Convert a list of SelectableFilter to nested filter structure use in core
+ * Convert a list of SelectableFilters into the nested filter structure used by Core
  */
 function transformAFilterSetToCoreFormat(
   filters: SelectableFilter[]
@@ -48,14 +48,14 @@ function transformAFilterSetToCoreFormat(
  * to a single nested filter stucture use in Answers Core
  */
 export function transformFiltersToCoreFormat(
-  filerCollections: Record<string, SelectableFilter[]> | null | undefined
+  filterCollection: Record<string, SelectableFilter[]> | null | undefined
 ): Filter | CombinedFilter | null {
-  if (!filerCollections) {
+  if (!filterCollection) {
     return null;
   }
 
   const coreFormattedFilters: (Filter | CombinedFilter)[] = [];
-  Object.values(filerCollections).forEach((selectableFilters: SelectableFilter[]) => {
+  Object.values(filterCollection).forEach((selectableFilters: SelectableFilter[]) => {
     const selectedFilters = selectableFilters.filter(selectableFilter => selectableFilter.selected);
     const transformedFilterSet = transformAFilterSetToCoreFormat(selectedFilters);
     transformedFilterSet && coreFormattedFilters.push(transformedFilterSet);

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -259,12 +259,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls.length).toBe(1);
     expect(dispatchEventCalls[0][0]).toBe('filters/addFilters');
     expect(dispatchEventCalls[0][1]).toEqual({
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filters: [filter, filter]
     });
   });
 
-  it('selectFilterOption works without filterSetId', async () => {
+  it('selectFilterOption works without filterCollectionId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -277,12 +277,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
-      filterSetId: undefined,
+      filterCollectionId: undefined,
       filter: filter
     });
   });
 
-  it('selectFilterOption works with filterSetId', async () => {
+  it('selectFilterOption works with filterCollectionId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -295,12 +295,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filter: filter
     });
   });
 
-  it('unselectFilterOption works without filterSetId', async () => {
+  it('unselectFilterOption works without filterCollectionId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -313,12 +313,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
-      filterSetId: undefined,
+      filterCollectionId: undefined,
       filter: filter
     });
   });
 
-  it('unselectFilterOption works with filterSetId', async () => {
+  it('unselectFilterOption works with filterCollectionId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -331,7 +331,7 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filter: filter
     });
   });

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -63,7 +63,7 @@ describe('setters work as expected', () => {
     jest.clearAllMocks();
   });
 
-  it('setFilter works as expected', () => {
+  it('setStaticFilters works as expected', () => {
     const filter: SelectableFilter = {
       filter: {
         fieldId: 'c_someField',
@@ -75,7 +75,7 @@ describe('setters work as expected', () => {
     const staticFilter = {
       someId: [filter]
     };
-    answers.setFilter(staticFilter);
+    answers.setStaticFilters(staticFilter);
 
     const dispatchEventCalls =
       mockedStateManager.dispatchEvent.mock.calls;
@@ -243,52 +243,13 @@ describe('filter functions work as expected', () => {
     jest.clearAllMocks();
   });
 
-  it('addFilters works', async () => {
-    const filter = {
-      filter: {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'someValue'
-      },
-      selected: false
-    };
-    answers.addFilters('someId', [filter, filter]);
-
-    const dispatchEventCalls =
-    mockedStateManager.dispatchEvent.mock.calls;
-    expect(dispatchEventCalls.length).toBe(1);
-    expect(dispatchEventCalls[0][0]).toBe('filters/addFilters');
-    expect(dispatchEventCalls[0][1]).toEqual({
-      filterCollectionId: 'someId',
-      filters: [filter, filter]
-    });
-  });
-
-  it('selectFilterOption works without filterCollectionId', async () => {
+  it('toggleFilterOption works when select filter', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.selectFilterOption(filter);
-    const dispatchEventCalls =
-    mockedStateManager.dispatchEvent.mock.calls;
-    expect(dispatchEventCalls.length).toBe(1);
-    expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
-    expect(dispatchEventCalls[0][1]).toEqual({
-      shouldSelect: true,
-      filterCollectionId: undefined,
-      filter: filter
-    });
-  });
-
-  it('selectFilterOption works with filterCollectionId', async () => {
-    const filter = {
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'someValue'
-    };
-    answers.selectFilterOption(filter, 'someId');
+    answers.toggleFilterOption('someId', filter, true);
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
@@ -300,31 +261,13 @@ describe('filter functions work as expected', () => {
     });
   });
 
-  it('unselectFilterOption works without filterCollectionId', async () => {
+  it('toggleFilterOption works when unselect filter', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.unselectFilterOption(filter);
-    const dispatchEventCalls =
-    mockedStateManager.dispatchEvent.mock.calls;
-    expect(dispatchEventCalls.length).toBe(1);
-    expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
-    expect(dispatchEventCalls[0][1]).toEqual({
-      shouldSelect: false,
-      filterCollectionId: undefined,
-      filter: filter
-    });
-  });
-
-  it('unselectFilterOption works with filterCollectionId', async () => {
-    const filter = {
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'someValue'
-    };
-    answers.unselectFilterOption(filter, 'someId');
+    answers.toggleFilterOption('someId', filter, false);
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -24,7 +24,7 @@ const mockedState = {
           matcher: Matcher.Equals,
           value: 'some value'
         },
-        selectable: true
+        selected: true
       }
     }
   },
@@ -68,7 +68,7 @@ describe('setters work as expected', () => {
         matcher: Matcher.Equals,
         value: 'someValue'
       },
-      selectable: true
+      selected: true
     };
     const staticFilter = {
       someId: filter

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -18,14 +18,16 @@ const mockedState = {
   },
   filters: {
     static: {
-      someId: {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value'
-        },
-        selected: true
-      }
+      someId: [
+        {
+          filter: {
+            fieldId: 'c_someField',
+            matcher: Matcher.Equals,
+            value: 'some value'
+          },
+          selected: true
+        }
+      ]
     }
   },
   spellCheck: {
@@ -71,7 +73,7 @@ describe('setters work as expected', () => {
       selected: true
     };
     const staticFilter = {
-      someId: filter
+      someId: [filter]
     };
     answers.setFilter(staticFilter);
 
@@ -243,9 +245,12 @@ describe('filter functions work as expected', () => {
 
   it('addFilters works', async () => {
     const filter = {
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'someValue'
+      filter: {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'someValue'
+      },
+      selected: false
     };
     answers.addFilters('someId', [filter, filter]);
 
@@ -381,7 +386,7 @@ describe('search works as expected', () => {
     const expectedSearchParams = {
       ...mockedState.query,
       verticalKey: mockedState.vertical.key,
-      staticFilters: mockedState.filters.static.someId.filter,
+      staticFilters: mockedState.filters.static.someId[0].filter,
       retrieveFacets: true,
       limit: mockedState.vertical.limit,
       offset: mockedState.vertical.offset,

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -20,11 +20,9 @@ const mockedState = {
     static: {
       someId: [
         {
-          filter: {
-            fieldId: 'c_someField',
-            matcher: Matcher.Equals,
-            value: 'some value'
-          },
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'some value',
           selected: true
         }
       ]
@@ -65,11 +63,9 @@ describe('setters work as expected', () => {
 
   it('setStaticFilters works as expected', () => {
     const filter: SelectableFilter = {
-      filter: {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'someValue'
-      },
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'someValue',
       selected: true
     };
     const staticFilter = {
@@ -249,7 +245,7 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption({ filter: filter, selected: true }, 'someId');
+    answers.toggleFilterOption({ ...filter, selected: true }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
@@ -267,7 +263,7 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption({ filter: filter, selected: false }, 'someId');
+    answers.toggleFilterOption({ ...filter, selected: false }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
@@ -324,12 +320,12 @@ describe('search works as expected', () => {
 
   it('vertical search works', async () => {
     await answers.executeVerticalQuery();
-
+    const { selected:_, ...filter } = mockedState.filters.static.someId[0];
     const coreCalls = mockedCore.verticalSearch.mock.calls;
     const expectedSearchParams = {
       ...mockedState.query,
       verticalKey: mockedState.vertical.key,
-      staticFilters: mockedState.filters.static.someId[0].filter,
+      staticFilters: filter,
       retrieveFacets: true,
       limit: mockedState.vertical.limit,
       offset: mockedState.vertical.offset,

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -254,12 +254,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls.length).toBe(1);
     expect(dispatchEventCalls[0][0]).toBe('filters/addFilters');
     expect(dispatchEventCalls[0][1]).toEqual({
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filters: [filter, filter]
     });
   });
 
-  it('selectFilterOption works without staticFiltersId', async () => {
+  it('selectFilterOption works without filterSetId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -272,12 +272,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
-      staticFiltersId: undefined,
+      filterSetId: undefined,
       filter: filter
     });
   });
 
-  it('selectFilterOption works with staticFiltersId', async () => {
+  it('selectFilterOption works with filterSetId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -290,12 +290,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filter: filter
     });
   });
 
-  it('unselectFilterOption works without staticFiltersId', async () => {
+  it('unselectFilterOption works without filterSetId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -308,12 +308,12 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
-      staticFiltersId: undefined,
+      filterSetId: undefined,
       filter: filter
     });
   });
 
-  it('unselectFilterOption works with staticFiltersId', async () => {
+  it('unselectFilterOption works with filterSetId', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
@@ -326,7 +326,7 @@ describe('filter functions work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filter: filter
     });
   });

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -239,17 +239,17 @@ describe('filter functions work as expected', () => {
     jest.clearAllMocks();
   });
 
-  it('toggleFilterOption works when select filter', async () => {
+  it('setFilterOption works when select filter', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption({ ...filter, selected: true }, 'someId');
+    answers.setFilterOption({ ...filter, selected: true }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
-    expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
+    expect(dispatchEventCalls[0][0]).toBe('filters/setFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
       filterCollectionId: 'someId',
@@ -257,17 +257,17 @@ describe('filter functions work as expected', () => {
     });
   });
 
-  it('toggleFilterOption works when unselect filter', async () => {
+  it('setFilterOption works when unselect filter', async () => {
     const filter = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption({ ...filter, selected: false }, 'someId');
+    answers.setFilterOption({ ...filter, selected: false }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
-    expect(dispatchEventCalls[0][0]).toBe('filters/toggleFilterOption');
+    expect(dispatchEventCalls[0][0]).toBe('filters/setFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
       filterCollectionId: 'someId',

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -249,7 +249,7 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption('someId', filter, true);
+    answers.toggleFilterOption({ filter: filter, selected: true }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
@@ -267,7 +267,7 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.toggleFilterOption('someId', filter, false);
+    answers.toggleFilterOption({ filter: filter, selected: false }, 'someId');
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -177,7 +177,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selectedExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with a non-existing filter in state when select', () => {
+  it('toggleFilterOption action is handled properly with filter not found in state when select', () => {
     const selectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {
@@ -200,7 +200,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selectedExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with filter not found when unselect', () => {
+  it('toggleFilterOption action is handled properly with filter not found in state when unselect', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -12,7 +12,7 @@ describe('filter slice reducer works as expected', () => {
   };
   const selectableFilter: SelectableFilter = {
     filter: filter,
-    selectable: false
+    selected: false
   };
 
   const initialState = {
@@ -26,7 +26,7 @@ describe('filter slice reducer works as expected', () => {
               matcher: Matcher.Equals,
               value: 'value1'
             },
-            selectable: true
+            selected: true
           },
           {
             combinator: FilterCombinator.OR,
@@ -37,7 +37,7 @@ describe('filter slice reducer works as expected', () => {
                   matcher: Matcher.Equals,
                   value: 'value2'
                 },
-                selectable: true
+                selected: true
               },
               {
                 filter: {
@@ -45,7 +45,7 @@ describe('filter slice reducer works as expected', () => {
                   matcher: Matcher.Equals,
                   value: 'value3'
                 },
-                selectable: false
+                selected: false
               }
             ]
           }
@@ -153,12 +153,12 @@ describe('filter slice reducer works as expected', () => {
 
     let actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
     const unselectExpectedState = _.cloneDeep(initialState);
-    unselectExpectedState.static.someId.filters[1].filters[0].selectable = false;
+    unselectExpectedState.static.someId.filters[1].filters[0].selected = false;
     expect(actualState).toEqual(unselectExpectedState);
 
     actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     const selecteExpectedState = _.cloneDeep(initialState);
-    selecteExpectedState.static.someId.filters[1].filters[1].selectable = true;
+    selecteExpectedState.static.someId.filters[1].filters[1].selected = true;
     expect(actualState).toEqual(selecteExpectedState);
   });
 
@@ -183,12 +183,12 @@ describe('filter slice reducer works as expected', () => {
 
     let actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
     const unselectExpectedState = _.cloneDeep(initialState);
-    unselectExpectedState.static.someId.filters[1].filters[0].selectable = false;
+    unselectExpectedState.static.someId.filters[1].filters[0].selected = false;
     expect(actualState).toEqual(unselectExpectedState);
 
     actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     const selecteExpectedState = _.cloneDeep(initialState);
-    selecteExpectedState.static.someId.filters[1].filters[1].selectable = true;
+    selecteExpectedState.static.someId.filters[1].filters[1].selected = true;
     expect(actualState).toEqual(selecteExpectedState);
   });
 

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -4,7 +4,7 @@ import createFiltersSlice from '../../../src/slices/filters';
 import _ from 'lodash';
 
 const { actions, reducer } = createFiltersSlice('');
-const { setStatic, setFacets, resetFacets, toggleFilterOption } = actions;
+const { setStatic, setFacets, resetFacets, setFilterOption } = actions;
 
 describe('filter slice reducer works as expected', () => {
 
@@ -55,7 +55,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(expectedState);
   });
 
-  it('toggleFilterOption action is handled properly with no static state', () => {
+  it('setFilterOption action is handled properly with no static state', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {
@@ -66,7 +66,7 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: true
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer({}, toggleFilterOption(unselectFilterPayload));
+    const actualState = reducer({}, setFilterOption(unselectFilterPayload));
     const expectedState = {
       static: {
         someId: [{
@@ -80,7 +80,7 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with unknown filterCollectionId on unselect', () => {
+  it('setFilterOption action is handled properly with unknown filterCollectionId on unselect', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'invalidId',
       filter: {
@@ -91,7 +91,7 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: false
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
+    const actualState = reducer(initialState, setFilterOption(unselectFilterPayload));
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(
@@ -100,7 +100,7 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with unknown filterCollectionId on select', () => {
+  it('setFilterOption action is handled properly with unknown filterCollectionId on select', () => {
     const selectFilterPayload = {
       filterCollectionId: 'newId',
       filter: {
@@ -111,7 +111,7 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: true
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     const selectExpectedState = _.cloneDeep(initialState);
     selectExpectedState.static['newId'] = [{ ...selectFilterPayload.filter, selected: true }];
     expect(actualState).toEqual(selectExpectedState);
@@ -119,7 +119,7 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with empty string for filterCollectionId', () => {
+  it('setFilterOption action is handled properly with empty string for filterCollectionId', () => {
     const selectFilterPayload = {
       filterCollectionId: '',
       filter: {
@@ -130,7 +130,7 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: true
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(
@@ -139,7 +139,7 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly, with valid filterCollectionId', () => {
+  it('setFilterOption action is handled properly, with valid filterCollectionId', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {
@@ -160,18 +160,18 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: true
     };
 
-    let actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
+    let actualState = reducer(initialState, setFilterOption(unselectFilterPayload));
     const unselectExpectedState = _.cloneDeep(initialState);
     unselectExpectedState.static.someId[1].selected = false;
     expect(actualState).toEqual(unselectExpectedState);
 
-    actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     const selectedExpectedState = _.cloneDeep(initialState);
     selectedExpectedState.static.someId[2].selected = true;
     expect(actualState).toEqual(selectedExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with filter not found in state when select', () => {
+  it('setFilterOption action is handled properly with filter not found in state when select', () => {
     const selectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {
@@ -181,7 +181,7 @@ describe('filter slice reducer works as expected', () => {
       },
       shouldSelect: true
     };
-    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     const selectedExpectedState = _.cloneDeep(initialState);
     selectedExpectedState.static.someId.push({
       ...selectFilterPayload.filter,
@@ -190,7 +190,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selectedExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with filter not found in state when unselect', () => {
+  it('setFilterOption action is handled properly with filter not found in state when unselect', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'someId',
       filter: {
@@ -201,7 +201,7 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: false
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
+    const actualState = reducer(initialState, setFilterOption(unselectFilterPayload));
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -101,7 +101,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-      expect.stringContaining('invalid static filters id')
+      expect.stringContaining('Could not unselect a non-existing filter option in state')
     );
     consoleWarnSpy.mockClear();
   });

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -69,12 +69,20 @@ describe('filter slice reducer works as expected', () => {
         matcher: Matcher.Equals,
         value: 'value2'
       },
-      shouldSelect: false
+      shouldSelect: true
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const actualState = reducer({}, toggleFilterOption(unselectFilterPayload));
-    expect(actualState).toEqual({});
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const expectedState = {
+      static: {
+        someId: [{
+          filter: unselectFilterPayload.filter,
+          selected: true
+        }]
+      }
+    };
+    expect(actualState).toEqual(expectedState);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
     consoleWarnSpy.mockClear();
   });
 

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -172,9 +172,9 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(unselectExpectedState);
 
     actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
-    const selecteExpectedState = _.cloneDeep(initialState);
-    selecteExpectedState.static.someId[2].selected = true;
-    expect(actualState).toEqual(selecteExpectedState);
+    const selectedExpectedState = _.cloneDeep(initialState);
+    selectedExpectedState.static.someId[2].selected = true;
+    expect(actualState).toEqual(selectedExpectedState);
   });
 
   it('toggleFilterOption action is handled properly with a non-existing filter in state when select', () => {
@@ -188,8 +188,8 @@ describe('filter slice reducer works as expected', () => {
       shouldSelect: true
     };
     const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
-    const selecteExpectedState = _.cloneDeep(initialState);
-    selecteExpectedState.static.someId.push({
+    const selectedExpectedState = _.cloneDeep(initialState);
+    selectedExpectedState.static.someId.push({
       filter: {
         fieldId: 'invalid field',
         matcher: Matcher.Equals,
@@ -197,7 +197,7 @@ describe('filter slice reducer works as expected', () => {
       },
       selected: true
     });
-    expect(actualState).toEqual(selecteExpectedState);
+    expect(actualState).toEqual(selectedExpectedState);
   });
 
   it('toggleFilterOption action is handled properly with filter not found when unselect', () => {

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -4,7 +4,7 @@ import createFiltersSlice from '../../../src/slices/filters';
 import _ from 'lodash';
 
 const { actions, reducer } = createFiltersSlice('');
-const { setStatic, setFacets, resetFacets, addFilters, toggleFilterOption } = actions;
+const { setStatic, setFacets, resetFacets, toggleFilterOption } = actions;
 
 describe('filter slice reducer works as expected', () => {
 
@@ -59,33 +59,6 @@ describe('filter slice reducer works as expected', () => {
     };
 
     expect(actualState).toEqual(expectedState);
-  });
-
-  it('addFilters action is handled properly', () => {
-    const firstStaticFilters = {
-      filterCollectionId: 'someId',
-      filters: [selectableFilter]
-    };
-    const SecondStaticFilters = {
-      filterCollectionId: 'anotherId',
-      filters: [selectableFilter, selectableFilter]
-    };
-
-    let actualState = reducer({}, addFilters(firstStaticFilters));
-    const firstExpectedState = {
-      static: {
-        someId: [selectableFilter]
-      }
-    };
-    expect(actualState).toEqual(firstExpectedState);
-    actualState = reducer(firstExpectedState, addFilters(SecondStaticFilters));
-    const secondExpectedState = {
-      static: {
-        someId: [selectableFilter],
-        anotherId: [selectableFilter, selectableFilter]
-      }
-    };
-    expect(actualState).toEqual(secondExpectedState);
   });
 
   it('toggleFilterOption action is handled properly with no static state', () => {
@@ -157,38 +130,32 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selecteExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly, with no filterCollectionId', () => {
-    const unselectFilterPayload = {
-      filter: {
-        fieldId: 'id2',
-        matcher: Matcher.Equals,
-        value: 'value2'
-      },
-      shouldSelect: false
-    };
-
+  it('toggleFilterOption action is handled properly with a non-existing filter in state when select', () => {
     const selectFilterPayload = {
+      filterCollectionId: 'someId',
       filter: {
-        fieldId: 'id3',
+        fieldId: 'invalid field',
         matcher: Matcher.Equals,
-        value: 'value3'
+        value: 'invalid value'
       },
       shouldSelect: true
     };
-
-    let actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
-    const unselectExpectedState = _.cloneDeep(initialState);
-    unselectExpectedState.static.someId[1].selected = false;
-    expect(actualState).toEqual(unselectExpectedState);
-
-    actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     const selecteExpectedState = _.cloneDeep(initialState);
-    selecteExpectedState.static.someId[2].selected = true;
+    selecteExpectedState.static.someId.push({
+      filter: {
+        fieldId: 'invalid field',
+        matcher: Matcher.Equals,
+        value: 'invalid value'
+      },
+      selected: true
+    });
     expect(actualState).toEqual(selecteExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with filter not found', () => {
+  it('toggleFilterOption action is handled properly with filter not found when unselect', () => {
     const unselectFilterPayload = {
+      filterCollectionId: 'someId',
       filter: {
         fieldId: 'invalid field',
         matcher: Matcher.Equals,
@@ -201,7 +168,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-      expect.stringContaining('Could not select a filter option with following fields')
+      expect.stringContaining('Could not unselect a non-existing filter option in state')
     );
     consoleWarnSpy.mockClear();
   });

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -63,11 +63,11 @@ describe('filter slice reducer works as expected', () => {
 
   it('addFilters action is handled properly', () => {
     const firstStaticFilters = {
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filters: [selectableFilter]
     };
     const SecondStaticFilters = {
-      filterSetId: 'anotherId',
+      filterCollectionId: 'anotherId',
       filters: [selectableFilter, selectableFilter]
     };
 
@@ -90,7 +90,7 @@ describe('filter slice reducer works as expected', () => {
 
   it('toggleFilterOption action is handled properly with no static state', () => {
     const unselectFilterPayload = {
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -105,9 +105,9 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with invalid filterSetId', () => {
+  it('toggleFilterOption action is handled properly with invalid filterCollectionId', () => {
     const unselectFilterPayload = {
-      filterSetId: 'invalidId',
+      filterCollectionId: 'invalidId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -125,9 +125,9 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly, with valid filterSetId', () => {
+  it('toggleFilterOption action is handled properly, with valid filterCollectionId', () => {
     const unselectFilterPayload = {
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -137,7 +137,7 @@ describe('filter slice reducer works as expected', () => {
     };
 
     const selectFilterPayload = {
-      filterSetId: 'someId',
+      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id3',
         matcher: Matcher.Equals,
@@ -157,7 +157,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selecteExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly, with no filterSetId', () => {
+  it('toggleFilterOption action is handled properly, with no filterCollectionId', () => {
     const unselectFilterPayload = {
       filter: {
         fieldId: 'id2',

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -78,7 +78,7 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with invalid filterCollectionId', () => {
+  it('toggleFilterOption action is handled properly with unknown filterCollectionId on unselect', () => {
     const unselectFilterPayload = {
       filterCollectionId: 'invalidId',
       filter: {
@@ -90,6 +90,45 @@ describe('filter slice reducer works as expected', () => {
     };
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const actualState = reducer(initialState, toggleFilterOption(unselectFilterPayload));
+    expect(actualState).toEqual(initialState);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect.stringContaining('invalid static filters id')
+    );
+    consoleWarnSpy.mockClear();
+  });
+
+  it('toggleFilterOption action is handled properly with unknown filterCollectionId on select', () => {
+    const selectFilterPayload = {
+      filterCollectionId: 'newId',
+      filter: {
+        fieldId: 'id2',
+        matcher: Matcher.Equals,
+        value: 'value2'
+      },
+      shouldSelect: true
+    };
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
+    const selectExpectedState = _.cloneDeep(initialState);
+    selectExpectedState.static['newId'] = [{filter: selectFilterPayload.filter, selected: true}];
+    expect(actualState).toEqual(selectExpectedState);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
+    consoleWarnSpy.mockClear();
+  });
+
+  it('toggleFilterOption action is handled properly with empty string for filterCollectionId', () => {
+    const selectFilterPayload = {
+      filterCollectionId: '',
+      filter: {
+        fieldId: 'id2',
+        matcher: Matcher.Equals,
+        value: 'value2'
+      },
+      shouldSelect: true
+    };
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     expect(actualState).toEqual(initialState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenLastCalledWith(

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -68,11 +68,11 @@ describe('filter slice reducer works as expected', () => {
 
   it('addFilters action is handled properly', () => {
     const firstStaticFilters = {
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filters: [filter]
     };
     const SecondStaticFilters = {
-      staticFiltersId: 'anotherId',
+      filterSetId: 'anotherId',
       filters: [filter, filter]
     };
 
@@ -98,7 +98,7 @@ describe('filter slice reducer works as expected', () => {
 
   it('toggleFilterOption action is handled properly with no static state', () => {
     const unselectFilterPayload = {
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -113,9 +113,9 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly with invalid staticFiltersId', () => {
+  it('toggleFilterOption action is handled properly with invalid filterSetId', () => {
     const unselectFilterPayload = {
-      staticFiltersId: 'invalidId',
+      filterSetId: 'invalidId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -130,9 +130,9 @@ describe('filter slice reducer works as expected', () => {
     consoleWarnSpy.mockClear();
   });
 
-  it('toggleFilterOption action is handled properly, with valid staticFiltersId', () => {
+  it('toggleFilterOption action is handled properly, with valid filterSetId', () => {
     const unselectFilterPayload = {
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -142,7 +142,7 @@ describe('filter slice reducer works as expected', () => {
     };
 
     const selectFilterPayload = {
-      staticFiltersId: 'someId',
+      filterSetId: 'someId',
       filter: {
         fieldId: 'id3',
         matcher: Matcher.Equals,
@@ -162,7 +162,7 @@ describe('filter slice reducer works as expected', () => {
     expect(actualState).toEqual(selecteExpectedState);
   });
 
-  it('toggleFilterOption action is handled properly with no staticFiltersId', () => {
+  it('toggleFilterOption action is handled properly with no filterSetId', () => {
     const unselectFilterPayload = {
       filter: {
         fieldId: 'id2',

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -14,7 +14,7 @@ describe('filter slice reducer works as expected', () => {
     matcher: Matcher.Equals
   };
   const selectableFilter: SelectableFilter = {
-    filter: filter,
+    ...filter,
     selected: false
   };
 
@@ -22,27 +22,21 @@ describe('filter slice reducer works as expected', () => {
     static: {
       someId: [
         {
-          filter: {
-            fieldId: 'id1',
-            matcher: Matcher.Equals,
-            value: 'value1'
-          },
+          fieldId: 'id1',
+          matcher: Matcher.Equals,
+          value: 'value1',
           selected: true
         },
         {
-          filter: {
-            fieldId: 'id2',
-            matcher: Matcher.Equals,
-            value: 'value2'
-          },
+          fieldId: 'id2',
+          matcher: Matcher.Equals,
+          value: 'value2',
           selected: true
         },
         {
-          filter: {
-            fieldId: 'id3',
-            matcher: Matcher.Equals,
-            value: 'value3'
-          },
+          fieldId: 'id3',
+          matcher: Matcher.Equals,
+          value: 'value3',
           selected: false
         }
       ]
@@ -76,7 +70,7 @@ describe('filter slice reducer works as expected', () => {
     const expectedState = {
       static: {
         someId: [{
-          filter: unselectFilterPayload.filter,
+          ...unselectFilterPayload.filter,
           selected: true
         }]
       }
@@ -119,7 +113,7 @@ describe('filter slice reducer works as expected', () => {
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     const selectExpectedState = _.cloneDeep(initialState);
-    selectExpectedState.static['newId'] = [{filter: selectFilterPayload.filter, selected: true}];
+    selectExpectedState.static['newId'] = [{ ...selectFilterPayload.filter, selected: true }];
     expect(actualState).toEqual(selectExpectedState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
     consoleWarnSpy.mockClear();
@@ -190,11 +184,7 @@ describe('filter slice reducer works as expected', () => {
     const actualState = reducer(initialState, toggleFilterOption(selectFilterPayload));
     const selectedExpectedState = _.cloneDeep(initialState);
     selectedExpectedState.static.someId.push({
-      filter: {
-        fieldId: 'invalid field',
-        matcher: Matcher.Equals,
-        value: 'invalid value'
-      },
+      ...selectFilterPayload.filter,
       selected: true
     });
     expect(actualState).toEqual(selectedExpectedState);

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -1,0 +1,231 @@
+import { CombinedFilter, Filter, FilterCombinator, Matcher } from '@yext/answers-core';
+import { CombinedSelectableFilter, SelectableFilter } from '../../../src/models/utils/selectablefilter';
+import {
+  transformFiltersToHeadlessFormat,
+  transformFiltersToCoreFormat
+} from '../../../src/utils/transform-filters';
+
+describe('see that transformFiltersToHeadlessFormat works properly', () => {
+  it('properly handle an empty list of filter', () => {
+    let transformedFilter = transformFiltersToHeadlessFormat(null);
+    expect(transformedFilter).toEqual(null);
+    transformedFilter = transformFiltersToHeadlessFormat([]);
+    expect(transformedFilter).toEqual(null);
+  });
+
+  it('properly handle one filter in given list', () => {
+    const filters: Filter[] = [{
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value'
+    }];
+
+    const expectedFilters: SelectableFilter = {
+      filter: filters[0],
+      selectable: false
+    };
+    const transformedFilter = transformFiltersToHeadlessFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle multiple filters of same group in given list', () => {
+    const filters: Filter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value'
+      },
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'a different value'
+      }
+    ];
+
+    const expectedFilters: CombinedSelectableFilter = {
+      combinator: FilterCombinator.OR,
+      filters: [
+        {
+          filter: filters[0],
+          selectable: false
+        },
+        {
+          filter: filters[1],
+          selectable: false
+        }
+      ]
+    };
+    const transformedFilter = transformFiltersToHeadlessFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle multiple filters of different groups in given list', () => {
+    const filters: Filter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'a different value'
+      },
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'unique value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'another value'
+      }
+    ];
+
+    const firstGroupedFilters: CombinedSelectableFilter = {
+      combinator: FilterCombinator.OR,
+      filters: [
+        {
+          filter: filters[0],
+          selectable: false
+        },
+        {
+          filter: filters[2],
+          selectable: false
+        }
+      ]
+    };
+
+    const secondGroupedFilters: CombinedSelectableFilter = {
+      combinator: FilterCombinator.OR,
+      filters: [
+        {
+          filter: filters[1],
+          selectable: false
+        },
+        {
+          filter: filters[3],
+          selectable: false
+        }
+      ]
+    };
+
+    const expectedFilters: CombinedSelectableFilter = {
+      combinator: FilterCombinator.AND,
+      filters: [firstGroupedFilters, secondGroupedFilters]
+    };
+    const transformedFilter = transformFiltersToHeadlessFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+});
+
+
+describe('see that transformFiltersToCoreFormat works properly', () => {
+  it('properly handle an undefined filter', () => {
+    const transformedFilter = transformFiltersToCoreFormat(undefined);
+    expect(transformedFilter).toEqual(null);
+  });
+
+  it('properly handle a Filter', () => {
+    const filters: Record<string, SelectableFilter> = {
+      someId: {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'some value'
+        },
+        selectable: true
+      }
+    };
+    const expectedFilters = filters.someId.filter;
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle a CombinedFilter', () => {
+    const filter = {
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value'
+    };
+    const filters: Record<string, CombinedSelectableFilter> = {
+      someId: {
+        combinator: FilterCombinator.OR,
+        filters: [
+          {
+            filter,
+            selectable: true
+          },
+          {
+            filter,
+            selectable: false
+          }
+        ]
+      }
+    };
+    const expectedFilters = {
+      combinator: FilterCombinator.OR,
+      filters: [filter, filter]
+    };
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle a list of Filter and CombinedFilter', () => {
+    const filter = {
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value'
+    };
+    const filters: Record<string, SelectableFilter | CombinedSelectableFilter> = {
+      someId: {
+        combinator: FilterCombinator.AND,
+        filters: [
+          {
+            filter,
+            selectable: true
+          },
+          {
+            filter,
+            selectable: false
+          }
+        ]
+      },
+      anotherId: {
+        filter,
+        selectable: false
+      },
+      randomId: {
+        combinator: FilterCombinator.OR,
+        filters: [
+          {
+            filter,
+            selectable: true
+          },
+          {
+            filter,
+            selectable: false
+          }
+        ]
+      }
+    };
+    const expectedFilters: Filter | CombinedFilter = {
+      combinator: FilterCombinator.AND,
+      filters: [
+        {
+          combinator: FilterCombinator.AND,
+          filters: [filter, filter]
+        },
+        filter,
+        {
+          combinator: FilterCombinator.OR,
+          filters: [filter, filter]
+        }
+      ]
+    };
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+});

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -22,7 +22,7 @@ describe('see that transformFiltersToHeadlessFormat works properly', () => {
 
     const expectedFilters: SelectableFilter = {
       filter: filters[0],
-      selectable: false
+      selected: false
     };
     const transformedFilter = transformFiltersToHeadlessFormat(filters);
     expect(transformedFilter).toEqual(expectedFilters);
@@ -47,11 +47,11 @@ describe('see that transformFiltersToHeadlessFormat works properly', () => {
       filters: [
         {
           filter: filters[0],
-          selectable: false
+          selected: false
         },
         {
           filter: filters[1],
-          selectable: false
+          selected: false
         }
       ]
     };
@@ -88,11 +88,11 @@ describe('see that transformFiltersToHeadlessFormat works properly', () => {
       filters: [
         {
           filter: filters[0],
-          selectable: false
+          selected: false
         },
         {
           filter: filters[2],
-          selectable: false
+          selected: false
         }
       ]
     };
@@ -102,11 +102,11 @@ describe('see that transformFiltersToHeadlessFormat works properly', () => {
       filters: [
         {
           filter: filters[1],
-          selectable: false
+          selected: false
         },
         {
           filter: filters[3],
-          selectable: false
+          selected: false
         }
       ]
     };
@@ -135,7 +135,7 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
           matcher: Matcher.Equals,
           value: 'some value'
         },
-        selectable: true
+        selected: true
       }
     };
     const expectedFilters = filters.someId.filter;
@@ -155,11 +155,11 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
         filters: [
           {
             filter,
-            selectable: true
+            selected: true
           },
           {
             filter,
-            selectable: false
+            selected: false
           }
         ]
       }
@@ -184,28 +184,28 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
         filters: [
           {
             filter,
-            selectable: true
+            selected: true
           },
           {
             filter,
-            selectable: false
+            selected: false
           }
         ]
       },
       anotherId: {
         filter,
-        selectable: false
+        selected: false
       },
       randomId: {
         combinator: FilterCombinator.OR,
         filters: [
           {
             filter,
-            selectable: true
+            selected: true
           },
           {
             filter,
-            selectable: false
+            selected: false
           }
         ]
       }

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -7,9 +7,6 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
     let transformedFilter = transformFiltersToCoreFormat(undefined);
     expect(transformedFilter).toEqual(null);
 
-    transformedFilter = transformFiltersToCoreFormat({someId: null, anotherId: null});
-    expect(transformedFilter).toEqual(null);
-
     transformedFilter = transformFiltersToCoreFormat({someId: []});
     expect(transformedFilter).toEqual(null);
   });

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -1,226 +1,115 @@
 import { CombinedFilter, Filter, FilterCombinator, Matcher } from '@yext/answers-core';
-import { CombinedSelectableFilter, SelectableFilter } from '../../../src/models/utils/selectablefilter';
-import {
-  transformFiltersToHeadlessFormat,
-  transformFiltersToCoreFormat
-} from '../../../src/utils/transform-filters';
-
-describe('see that transformFiltersToHeadlessFormat works properly', () => {
-  it('properly handle an empty list of filter', () => {
-    let transformedFilter = transformFiltersToHeadlessFormat(null);
-    expect(transformedFilter).toEqual(null);
-    transformedFilter = transformFiltersToHeadlessFormat([]);
-    expect(transformedFilter).toEqual(null);
-  });
-
-  it('properly handle one filter in given list', () => {
-    const filters: Filter[] = [{
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'some value'
-    }];
-
-    const expectedFilters: SelectableFilter = {
-      filter: filters[0],
-      selected: false
-    };
-    const transformedFilter = transformFiltersToHeadlessFormat(filters);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-
-  it('properly handle multiple filters of same group in given list', () => {
-    const filters: Filter[] = [
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'some value'
-      },
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'a different value'
-      }
-    ];
-
-    const expectedFilters: CombinedSelectableFilter = {
-      combinator: FilterCombinator.OR,
-      filters: [
-        {
-          filter: filters[0],
-          selected: false
-        },
-        {
-          filter: filters[1],
-          selected: false
-        }
-      ]
-    };
-    const transformedFilter = transformFiltersToHeadlessFormat(filters);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-
-  it('properly handle multiple filters of different groups in given list', () => {
-    const filters: Filter[] = [
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'some value'
-      },
-      {
-        fieldId: 'c_aDifferentField',
-        matcher: Matcher.Equals,
-        value: 'a different value'
-      },
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'unique value'
-      },
-      {
-        fieldId: 'c_aDifferentField',
-        matcher: Matcher.Equals,
-        value: 'another value'
-      }
-    ];
-
-    const firstGroupedFilters: CombinedSelectableFilter = {
-      combinator: FilterCombinator.OR,
-      filters: [
-        {
-          filter: filters[0],
-          selected: false
-        },
-        {
-          filter: filters[2],
-          selected: false
-        }
-      ]
-    };
-
-    const secondGroupedFilters: CombinedSelectableFilter = {
-      combinator: FilterCombinator.OR,
-      filters: [
-        {
-          filter: filters[1],
-          selected: false
-        },
-        {
-          filter: filters[3],
-          selected: false
-        }
-      ]
-    };
-
-    const expectedFilters: CombinedSelectableFilter = {
-      combinator: FilterCombinator.AND,
-      filters: [firstGroupedFilters, secondGroupedFilters]
-    };
-    const transformedFilter = transformFiltersToHeadlessFormat(filters);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-});
-
+import { SelectableFilter } from '../../../src/models/utils/selectablefilter';
+import { transformFiltersToCoreFormat } from '../../../src/utils/transform-filters';
 
 describe('see that transformFiltersToCoreFormat works properly', () => {
   it('properly handle an undefined filter', () => {
-    const transformedFilter = transformFiltersToCoreFormat(undefined);
+    let transformedFilter = transformFiltersToCoreFormat(undefined);
+    expect(transformedFilter).toEqual(null);
+
+    transformedFilter = transformFiltersToCoreFormat({someId: null, anotherId: null});
+    expect(transformedFilter).toEqual(null);
+
+    transformedFilter = transformFiltersToCoreFormat({someId: []});
     expect(transformedFilter).toEqual(null);
   });
 
-  it('properly handle a Filter', () => {
-    const filters: Record<string, SelectableFilter> = {
-      someId: {
+  it('properly handle a selected Filter', () => {
+    const filters: Record<string, SelectableFilter[]> = {
+      someId: [
+        {
+          filter: {
+            fieldId: 'c_someField',
+            matcher: Matcher.Equals,
+            value: 'some value'
+          },
+          selected: true
+        }
+      ]
+    };
+    const expectedFilters = filters.someId[0].filter;
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle selected multiple filters of same group', () => {
+    const filter = {
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value'
+    };
+    const filters: Record<string, SelectableFilter[]> = {
+      someId: [
+        {
+          filter,
+          selected: true
+        },
+        {
+          filter,
+          selected: true
+        },
+        {
+          filter,
+          selected: true
+        }
+      ]
+    };
+    const expectedFilters = {
+      combinator: FilterCombinator.OR,
+      filters: [filter, filter, filter]
+    };
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle selected filters of different groups', () => {
+    const selectableFilters: SelectableFilter[] = [
+      {
         filter: {
           fieldId: 'c_someField',
           matcher: Matcher.Equals,
           value: 'some value'
         },
         selected: true
-      }
-    };
-    const expectedFilters = filters.someId.filter;
-    const transformedFilter = transformFiltersToCoreFormat(filters);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-
-  it('properly handle a CombinedFilter', () => {
-    const filter = {
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'some value'
-    };
-    const filters: Record<string, CombinedSelectableFilter> = {
-      someId: {
-        combinator: FilterCombinator.OR,
-        filters: [
-          {
-            filter,
-            selected: true
-          },
-          {
-            filter,
-            selected: false
-          }
-        ]
-      }
-    };
-    const expectedFilters = {
-      combinator: FilterCombinator.OR,
-      filters: [filter, filter]
-    };
-    const transformedFilter = transformFiltersToCoreFormat(filters);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-
-  it('properly handle a list of Filter and CombinedFilter', () => {
-    const filter = {
-      fieldId: 'c_someField',
-      matcher: Matcher.Equals,
-      value: 'some value'
-    };
-    const filters: Record<string, SelectableFilter | CombinedSelectableFilter> = {
-      someId: {
-        combinator: FilterCombinator.AND,
-        filters: [
-          {
-            filter,
-            selected: true
-          },
-          {
-            filter,
-            selected: false
-          }
-        ]
       },
-      anotherId: {
-        filter,
-        selected: false
+      {
+        filter: {
+          fieldId: 'c_aDifferentField',
+          matcher: Matcher.Equals,
+          value: 'a different value'
+        },
+        selected: true
       },
-      randomId: {
-        combinator: FilterCombinator.OR,
-        filters: [
-          {
-            filter,
-            selected: true
-          },
-          {
-            filter,
-            selected: false
-          }
-        ]
+      {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'unique value'
+        },
+        selected: true
+      },
+      {
+        filter: {
+          fieldId: 'c_aDifferentField',
+          matcher: Matcher.Equals,
+          value: 'another value'
+        },
+        selected: true
       }
+    ];
+    const filters = {
+      someId: selectableFilters
     };
     const expectedFilters: Filter | CombinedFilter = {
       combinator: FilterCombinator.AND,
       filters: [
         {
-          combinator: FilterCombinator.AND,
-          filters: [filter, filter]
+          combinator: FilterCombinator.OR,
+          filters: [filters.someId[0].filter, filters.someId[2].filter]
         },
-        filter,
         {
           combinator: FilterCombinator.OR,
-          filters: [filter, filter]
+          filters: [filters.someId[1].filter, filters.someId[3].filter]
         }
       ]
     };
@@ -228,4 +117,123 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
+  it('properly handle a mix of unselected and selected filters of different groups', () => {
+    const selectableFilters: SelectableFilter[] = [
+      {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'some value'
+        },
+        selected: false
+      },
+      {
+        filter: {
+          fieldId: 'c_aDifferentField',
+          matcher: Matcher.Equals,
+          value: 'a different value'
+        },
+        selected: false
+      },
+      {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'unique value'
+        },
+        selected: true
+      },
+      {
+        filter: {
+          fieldId: 'c_aDifferentField',
+          matcher: Matcher.Equals,
+          value: 'another value'
+        },
+        selected: true
+      }
+    ];
+    const filters = {
+      someId: selectableFilters
+    };
+    const expectedFilters: Filter | CombinedFilter = {
+      combinator: FilterCombinator.AND,
+      filters: [filters.someId[2].filter, filters.someId[3].filter]
+    };
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
+
+  it('properly handle selected filters of different groups with different filterSetIds', () => {
+    const someIdSelectableFilters: SelectableFilter[] = [
+      {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'some value'
+        },
+        selected: true
+      },
+      {
+        filter: {
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'unique value'
+        },
+        selected: true
+      },
+      {
+        filter: {
+          fieldId: 'c_differentField',
+          matcher: Matcher.Equals,
+          value: 'very unique value'
+        },
+        selected: true
+      }
+    ];
+
+    const anotherIdSelectableFilters: SelectableFilter[] = [
+      {
+        filter: {
+          fieldId: 'c_anotherField',
+          matcher: Matcher.Equals,
+          value: 'another value'
+        },
+        selected: true
+      },
+      {
+        filter: {
+          fieldId: 'c_anotherField',
+          matcher: Matcher.Equals,
+          value: 'unique value'
+        },
+        selected: true
+      }
+    ];
+
+    const filters = {
+      someId: someIdSelectableFilters,
+      anotherId: anotherIdSelectableFilters
+    };
+    const expectedFilters: Filter | CombinedFilter = {
+      combinator: FilterCombinator.AND,
+      filters: [
+        {
+          combinator: FilterCombinator.AND,
+          filters: [
+            {
+              combinator: FilterCombinator.OR,
+              filters: [filters.someId[0].filter, filters.someId[1].filter]
+            },
+            filters.someId[2].filter
+          ]
+        },
+        {
+          combinator: FilterCombinator.OR,
+          filters: [filters.anotherId[0].filter, filters.anotherId[1].filter]
+        }
+      ]
+    };
+    const transformedFilter = transformFiltersToCoreFormat(filters);
+    expect(transformedFilter).toEqual(expectedFilters);
+  });
 });

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -15,16 +15,18 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
     const filters: Record<string, SelectableFilter[]> = {
       someId: [
         {
-          filter: {
-            fieldId: 'c_someField',
-            matcher: Matcher.Equals,
-            value: 'some value'
-          },
+          fieldId: 'c_someField',
+          matcher: Matcher.Equals,
+          value: 'some value',
           selected: true
         }
       ]
     };
-    const expectedFilters = filters.someId[0].filter;
+    const expectedFilters = {
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value'
+    };
     const transformedFilter = transformFiltersToCoreFormat(filters);
     expect(transformedFilter).toEqual(expectedFilters);
   });
@@ -35,21 +37,12 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
       matcher: Matcher.Equals,
       value: 'some value'
     };
+    const selectableFilter = {
+      ...filter,
+      selected: true
+    };
     const filters: Record<string, SelectableFilter[]> = {
-      someId: [
-        {
-          filter,
-          selected: true
-        },
-        {
-          filter,
-          selected: true
-        },
-        {
-          filter,
-          selected: true
-        }
-      ]
+      someId: [selectableFilter, selectableFilter, selectableFilter]
     };
     const expectedFilters = {
       combinator: FilterCombinator.OR,
@@ -60,41 +53,48 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
   });
 
   it('properly handle selected filters of different groups', () => {
+    const filters: Filter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'a different value'
+      },
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'unique value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'another value'
+      }
+    ];
+
     const selectableFilters: SelectableFilter[] = [
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value'
-        },
+        ...filters[0],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_aDifferentField',
-          matcher: Matcher.Equals,
-          value: 'a different value'
-        },
+        ...filters[1],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'unique value'
-        },
+        ...filters[2],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_aDifferentField',
-          matcher: Matcher.Equals,
-          value: 'another value'
-        },
+        ...filters[3],
         selected: true
       }
     ];
-    const filters = {
+    const filterCollections = {
       someId: selectableFilters
     };
     const expectedFilters: Filter | CombinedFilter = {
@@ -102,107 +102,125 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
       filters: [
         {
           combinator: FilterCombinator.OR,
-          filters: [filters.someId[0].filter, filters.someId[2].filter]
+          filters: [filters[0], filters[2]]
         },
         {
           combinator: FilterCombinator.OR,
-          filters: [filters.someId[1].filter, filters.someId[3].filter]
+          filters: [filters[1], filters[3]]
         }
       ]
     };
-    const transformedFilter = transformFiltersToCoreFormat(filters);
+    const transformedFilter = transformFiltersToCoreFormat(filterCollections);
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
   it('properly handle a mix of unselected and selected filters of different groups', () => {
+    const filters: Filter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'a different value'
+      },
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'unique value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'another value'
+      }
+    ];
+
     const selectableFilters: SelectableFilter[] = [
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value'
-        },
+        ...filters[0],
         selected: false
       },
       {
-        filter: {
-          fieldId: 'c_aDifferentField',
-          matcher: Matcher.Equals,
-          value: 'a different value'
-        },
+        ...filters[1],
         selected: false
       },
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'unique value'
-        },
+        ...filters[2],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_aDifferentField',
-          matcher: Matcher.Equals,
-          value: 'another value'
-        },
+        ...filters[3],
         selected: true
       }
     ];
-    const filters = {
+    const filterCollections = {
       someId: selectableFilters
     };
     const expectedFilters: Filter | CombinedFilter = {
       combinator: FilterCombinator.AND,
-      filters: [filters.someId[2].filter, filters.someId[3].filter]
+      filters: [filters[2], filters[3]]
     };
-    const transformedFilter = transformFiltersToCoreFormat(filters);
+    const transformedFilter = transformFiltersToCoreFormat(filterCollections);
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
   it('properly handle selected filters of different groups with different filterCollectionIds', () => {
+    const someIdfilters: Filter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value'
+      },
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'unique value'
+      },
+      {
+        fieldId: 'c_aDifferentField',
+        matcher: Matcher.Equals,
+        value: 'very unique value'
+      }
+    ];
+
     const someIdSelectableFilters: SelectableFilter[] = [
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value'
-        },
+        ...someIdfilters[0],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'unique value'
-        },
+        ...someIdfilters[1],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_differentField',
-          matcher: Matcher.Equals,
-          value: 'very unique value'
-        },
+        ...someIdfilters[2],
         selected: true
+      }
+    ];
+
+    const anotherIdfilters: Filter[] = [
+      {
+        fieldId: 'c_anotherField',
+        matcher: Matcher.Equals,
+        value: 'another value'
+      },
+      {
+        fieldId: 'c_anotherField',
+        matcher: Matcher.Equals,
+        value: 'unique value'
       }
     ];
 
     const anotherIdSelectableFilters: SelectableFilter[] = [
       {
-        filter: {
-          fieldId: 'c_anotherField',
-          matcher: Matcher.Equals,
-          value: 'another value'
-        },
+        ...anotherIdfilters[0],
         selected: true
       },
       {
-        filter: {
-          fieldId: 'c_anotherField',
-          matcher: Matcher.Equals,
-          value: 'unique value'
-        },
+        ...anotherIdfilters[1],
         selected: true
       }
     ];
@@ -219,14 +237,14 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
           filters: [
             {
               combinator: FilterCombinator.OR,
-              filters: [filters.someId[0].filter, filters.someId[1].filter]
+              filters: [someIdfilters[0], someIdfilters[1]]
             },
-            filters.someId[2].filter
+            someIdfilters[2]
           ]
         },
         {
           combinator: FilterCombinator.OR,
-          filters: [filters.anotherId[0].filter, filters.anotherId[1].filter]
+          filters: [anotherIdfilters[0], anotherIdfilters[1]]
         }
       ]
     };

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -163,7 +163,7 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
-  it('properly handle selected filters of different groups with different filterSetIds', () => {
+  it('properly handle selected filters of different groups with different filterCollectionIds', () => {
     const someIdSelectableFilters: SelectableFilter[] = [
       {
         filter: {


### PR DESCRIPTION
This PR aim to solve two issues: 1) current setup can't support multiple static filters 2) StaticFilter have its own FilterState from answers-headless FilterState. This cause problems where applied filters have to use workaround (trigger click event) to update filter option for static filter. 

- update static in FilterState to handle support for multiple static filters using a map of `filterCollectionId` to a list of `SelectableFilter`s. When send to core, these chunks of filters will be transform to the nested structure and will be AND together.
- update static in FilterState to support `selected` option field
- update answers-headless and filter slice to include `setFilterOption`.
- add helper functions to convert filter structure a list of `SelectableFilter` to core format.
- add jest tests

will release version 0.1.0-beta.2 when merged

J=SLAP-1661
TEST=auto

see that jest tests passed