### PR TITLE
Top level direct answer slice

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,8 +1,9 @@
-The following NPM package may be included in this product:
+The following NPM packages may be included in this product:
 
  - @babel/runtime-corejs3@7.15.4
+ - @babel/runtime@7.14.6
 
-This package contains the following license and notice below:
+These packages each contain the following license and notice below:
 
 MIT License
 
@@ -31,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @reduxjs/toolkit@1.5.0
+ - @reduxjs/toolkit@1.6.0
 
 This package contains the following license and notice below:
 
@@ -158,7 +159,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - immer@8.0.1
+ - immer@9.0.6
 
 This package contains the following license and notice below:
 
@@ -218,66 +219,6 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - js-tokens@4.0.0
-
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - loose-envify@1.4.0
-
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
  - node-fetch@2.6.1
 
 This package contains the following license and notice below:
@@ -309,7 +250,7 @@ SOFTWARE.
 The following NPM packages may be included in this product:
 
  - redux-thunk@2.3.0
- - redux@4.0.5
+ - redux@4.1.1
 
 These packages each contain the following license and notice below:
 
@@ -394,37 +335,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
------------
-
-The following NPM package may be included in this product:
-
- - symbol-observable@1.2.0
-
-This package contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-Copyright (c) Ben Lesh <ben@benlesh.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 -----------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.0",

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -160,6 +160,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('query/setSearchIntents', results.searchIntents || []);
     this.stateManager.dispatchEvent('location/setLocationBias', results.locationBias);
     this.stateManager.dispatchEvent('universal/setSearchLoading', false);
+    this.stateManager.dispatchEvent('directAnswer/setResult', results.directAnswer);
     return results;
   }
 
@@ -241,6 +242,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('query/setSearchIntents', results.searchIntents || []);
     this.stateManager.dispatchEvent('location/setLocationBias', results.locationBias);
     this.stateManager.dispatchEvent('vertical/setSearchLoading', false);
+    this.stateManager.dispatchEvent('directAnswer/setResult', results.directAnswer);
     return results;
   }
 

--- a/src/headless-reducer-manager.ts
+++ b/src/headless-reducer-manager.ts
@@ -10,6 +10,7 @@ import createSessionTrackingSlice from './slices/sessiontracking';
 import createMetaSlice from './slices/meta';
 import createLocationSlice from './slices/location';
 import { ActionWithHeadlessId } from './store';
+import createDirectAnswerSlice from './slices/directanswer';
 
 /**
  * Manages the current map of headless IDs to Reducers.
@@ -43,6 +44,7 @@ function createAnswersReducer(prefix: string): Reducer<State> {
     query: createQuerySlice(prefix).reducer,
     vertical: createVerticalSlice(prefix).reducer,
     universal: createUniversalSlice(prefix).reducer,
+    directAnswer: createDirectAnswerSlice(prefix).reducer,
     filters: createFiltersSlice(prefix).reducer,
     spellCheck: createSpellCheckSlice(prefix).reducer,
     sessionTracking: createSessionTrackingSlice(prefix).reducer,

--- a/src/models/slices/directanswer.ts
+++ b/src/models/slices/directanswer.ts
@@ -1,0 +1,5 @@
+import { FeaturedSnippetDirectAnswer, FieldValueDirectAnswer } from '@yext/answers-core';
+
+export interface DirectAnswerState {
+  result?: FeaturedSnippetDirectAnswer | FieldValueDirectAnswer;
+}

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -6,6 +6,7 @@ import { SpellCheckState } from './slices/spellcheck';
 import { MetaState } from './slices/meta';
 import { LocationState } from './slices/location';
 import { SessionTrackingState } from './slices/sessiontracking';
+import { DirectAnswerState } from './slices/directanswer';
 
 /**
  * The overall shape of the redux state tree, with each key value pair
@@ -19,6 +20,7 @@ export interface State {
   query: QueryState,
   universal: UniversalSearchState,
   vertical: VerticalSearchState,
+  directAnswer: DirectAnswerState,
   filters: FiltersState,
   spellCheck: SpellCheckState,
   sessionTracking: SessionTrackingState

--- a/src/slices/directanswer.ts
+++ b/src/slices/directanswer.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
+import { FeaturedSnippetDirectAnswer, FieldValueDirectAnswer } from '@yext/answers-core';
+import { DirectAnswerState } from '../models/slices/directanswer';
+
+const initialState: DirectAnswerState = {};
+
+const reducers = {
+  setResult: (
+    state: DirectAnswerState,
+    action: PayloadAction<FeaturedSnippetDirectAnswer | FieldValueDirectAnswer>
+  ) => {
+    state.result = action.payload;
+  },
+};
+
+/**
+ * Registers with Redux the slice of {@link State} pertaining to direct answers.
+ */
+export default function createDirectAnswerSlice(prefix: string): Slice<DirectAnswerState, typeof reducers> {
+  return createSlice({
+    name: prefix + 'directAnswer',
+    initialState,
+    reducers
+  });
+}

--- a/src/slices/directanswer.ts
+++ b/src/slices/directanswer.ts
@@ -7,7 +7,7 @@ const initialState: DirectAnswerState = {};
 const reducers = {
   setResult: (
     state: DirectAnswerState,
-    action: PayloadAction<FeaturedSnippetDirectAnswer | FieldValueDirectAnswer>
+    action: PayloadAction<FeaturedSnippetDirectAnswer | FieldValueDirectAnswer | undefined>
   ) => {
     state.result = action.payload;
   },

--- a/tests/integration/directanswer.ts
+++ b/tests/integration/directanswer.ts
@@ -1,0 +1,55 @@
+import { createMockedAnswersHeadless } from '../mocks/createMockedAnswersHeadless';
+import { FeaturedSnippetDirectAnswer, DirectAnswerType, Source} from '@yext/answers-core';
+
+const initialState = {
+  query: {
+    latest: 'virginia',
+    query: 'virginia'
+  },
+  vertical: {
+    key: '123'
+  },
+  directAnswer: {},
+  universal: {},
+  filters: {},
+  spellCheck: {
+    enabled: true,
+  },
+};
+
+const featuredSnippedDirectAnswer: FeaturedSnippetDirectAnswer = {
+  type: DirectAnswerType.FeaturedSnippet,
+  relatedResult: {
+    rawData: {},
+    source: Source.KnowledgeManager
+  },
+  verticalKey: 'people',
+  fieldType: 'c_name',
+  snippet: {
+    value: 'Bob',
+    matchedSubstrings: [{ offset: 0, length: 3}]
+  }
+};
+
+function mockSearchWithFeaturedSnippedDirectAnswer() {
+  return Promise.resolve({
+    directAnswer: featuredSnippedDirectAnswer
+  });
+}
+
+describe('AnswersHeadless spellcheck interactions properly update state', () => {
+  it('executeVerticalQuery properly updates direct answer state', async () => {
+    const answers = createMockedAnswersHeadless({
+      verticalSearch: mockSearchWithFeaturedSnippedDirectAnswer
+    }, initialState);
+    await answers.executeVerticalQuery();
+    const expectedState = {
+      ...initialState,
+      directAnswer: {
+        result: featuredSnippedDirectAnswer
+      }
+    };
+
+    expect(answers.state).toMatchObject(expectedState);
+  });
+});

--- a/tests/integration/directanswer.ts
+++ b/tests/integration/directanswer.ts
@@ -1,5 +1,5 @@
 import { createMockedAnswersHeadless } from '../mocks/createMockedAnswersHeadless';
-import { FeaturedSnippetDirectAnswer, DirectAnswerType, Source} from '@yext/answers-core';
+import { FeaturedSnippetDirectAnswer, DirectAnswerType, Source } from '@yext/answers-core';
 
 const initialState = {
   query: {

--- a/tests/integration/directanswer.ts
+++ b/tests/integration/directanswer.ts
@@ -31,22 +31,50 @@ const featuredSnippedDirectAnswer: FeaturedSnippetDirectAnswer = {
   }
 };
 
-function mockSearchWithFeaturedSnippedDirectAnswer() {
-  return Promise.resolve({
-    directAnswer: featuredSnippedDirectAnswer
-  });
-}
-
 describe('AnswersHeadless spellcheck interactions properly update state', () => {
   it('executeVerticalQuery properly updates direct answer state', async () => {
     const answers = createMockedAnswersHeadless({
-      verticalSearch: mockSearchWithFeaturedSnippedDirectAnswer
+      verticalSearch: () => Promise.resolve({ directAnswer: featuredSnippedDirectAnswer })
     }, initialState);
     await answers.executeVerticalQuery();
     const expectedState = {
       ...initialState,
       directAnswer: {
         result: featuredSnippedDirectAnswer
+      }
+    };
+
+    expect(answers.state).toMatchObject(expectedState);
+  });
+
+  it('executeUniversalQuery properly updates direct answer state', async () => {
+    const answers = createMockedAnswersHeadless({
+      universalSearch: () => Promise.resolve({ directAnswer: featuredSnippedDirectAnswer })
+    }, initialState);
+    await answers.executeUniversalQuery();
+    const expectedState = {
+      ...initialState,
+      directAnswer: {
+        result: featuredSnippedDirectAnswer
+      }
+    };
+
+    expect(answers.state).toMatchObject(expectedState);
+  });
+
+  it('An undefined direct answer results in an undefined direct answer state', async () => {
+    const initialStateWithDA = {
+      ...initialState,
+      directAnswer: { result: featuredSnippedDirectAnswer }
+    };
+    const answers = createMockedAnswersHeadless({
+      universalSearch: () => Promise.resolve({ directAnswer: undefined })
+    }, initialStateWithDA);
+    await answers.executeUniversalQuery();
+    const expectedState = {
+      ...initialState,
+      directAnswer: {
+        result: undefined
       }
     };
 

--- a/tests/mocks/expectedInitialState.ts
+++ b/tests/mocks/expectedInitialState.ts
@@ -12,5 +12,6 @@ export const expectedInitialState: State = {
     enabled: true
   },
   universal: {},
-  vertical: {}
+  vertical: {},
+  directAnswer: {}
 };


### PR DESCRIPTION
Create a slice for direct answers at the top level of the state

I originally tried using the direct answer models as the state of the slice, however I was running into problems with redux when attempting it. I was able to get it working by putting the direct answer under a prop which I called 'result'. I believe that putting the direct answer under a prop is the best way of maintaining the typescript discriminating union. I think It reads well, and it gives us flexibility in case we need to add anything to the direct answer state which is specific to headless.

J=SLAP-1664
TEST=auto

Add unit test which confirms the direct answer is set properly in this new slice