### PR TITLE
Add support for FilterSearch

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -1,9 +1,8 @@
-The following NPM packages may be included in this product:
+The following NPM package may be included in this product:
 
  - @babel/runtime-corejs3@7.15.4
- - @babel/runtime@7.14.6
 
-These packages each contain the following license and notice below:
+This package contains the following license and notice below:
 
 MIT License
 
@@ -32,7 +31,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @reduxjs/toolkit@1.6.0
+ - @reduxjs/toolkit@1.5.0
 
 This package contains the following license and notice below:
 
@@ -159,7 +158,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - immer@9.0.6
+ - immer@8.0.1
 
 This package contains the following license and notice below:
 
@@ -219,6 +218,66 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
+ - js-tokens@4.0.0
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
+ - loose-envify@1.4.0
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
  - node-fetch@2.6.1
 
 This package contains the following license and notice below:
@@ -250,7 +309,7 @@ SOFTWARE.
 The following NPM packages may be included in this product:
 
  - redux-thunk@2.3.0
- - redux@4.1.1
+ - redux@4.0.5
 
 These packages each contain the following license and notice below:
 
@@ -335,6 +394,37 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-----------
+
+The following NPM package may be included in this product:
+
+ - symbol-observable@1.2.0
+
+This package contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Copyright (c) Ben Lesh <ben@benlesh.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 -----------
 

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -283,7 +283,6 @@ export default class AnswersHeadless {
   ): Promise<FilterSearchResponse | undefined> {
     const thisRequestId = this.httpManager.updateRequestId('filterSearch');
     const verticalKey = this.state.vertical.key;
-    console.log(verticalKey);
     if (!verticalKey) {
       console.error('no verticalKey supplied for filter search');
       return;

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -14,7 +14,6 @@ import {
   Context,
   LatLong,
   SearchParameterField,
-  FilterSearchResponse,
   UniversalLimit
 } from '@yext/answers-core';
 
@@ -280,7 +279,7 @@ export default class AnswersHeadless {
     filterSearchId: string,
     sectioned: boolean,
     fields: SearchParameterField[]
-  ): Promise<FilterSearchResponse | undefined> {
+  ): Promise<void> {
     const thisRequestId = this.httpManager.updateRequestId('filterSearch');
     const verticalKey = this.state.vertical.key;
     if (!verticalKey) {
@@ -308,7 +307,7 @@ export default class AnswersHeadless {
 
     const latestResponseId = this.httpManager.getLatestResponseId('filterSearch');
     if (thisRequestId < latestResponseId) {
-      return results;
+      return;
     }
     const payload = {
       filterSearchId,
@@ -316,7 +315,6 @@ export default class AnswersHeadless {
     };
     this.httpManager.setResponseId('filterSearch', thisRequestId);
     this.stateManager.dispatchEvent('filterSearch/setResults', payload);
-    return results;
   }
 
   selectFacetOption(fieldId: string, facetOption: FacetOption): void {

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -287,8 +287,14 @@ export default class AnswersHeadless {
       console.error('no verticalKey supplied for filter search');
       return;
     }
-    if (!filterSearchId || !this.state.filterSearch[filterSearchId]) {
-      console.error(`invalid filterSearch id: "${filterSearchId}""`);
+    if (!filterSearchId) {
+      console.error('Unable to execute filter search. ' +
+      `invalid filterSearch id: "${filterSearchId}". Id must be a non-empty string.`);
+      return;
+    }
+    if (!this.state.filterSearch[filterSearchId]) {
+      console.error('Unable to execute filter search. The following filterSearch id does not exist in state: '
+      + `"${filterSearchId}".`);
       return;
     }
 

--- a/src/headless-reducer-manager.ts
+++ b/src/headless-reducer-manager.ts
@@ -10,6 +10,7 @@ import createSessionTrackingSlice from './slices/sessiontracking';
 import createMetaSlice from './slices/meta';
 import createLocationSlice from './slices/location';
 import { ActionWithHeadlessId } from './store';
+import createFilterSearchSlice from './slices/filtersearch';
 
 /**
  * Manages the current map of headless IDs to Reducers.
@@ -43,6 +44,7 @@ function createAnswersReducer(prefix: string): Reducer<State> {
     query: createQuerySlice(prefix).reducer,
     vertical: createVerticalSlice(prefix).reducer,
     universal: createUniversalSlice(prefix).reducer,
+    filterSearch: createFilterSearchSlice(prefix).reducer,
     filters: createFiltersSlice(prefix).reducer,
     spellCheck: createSpellCheckSlice(prefix).reducer,
     sessionTracking: createSessionTrackingSlice(prefix).reducer,

--- a/src/http-manager.ts
+++ b/src/http-manager.ts
@@ -1,7 +1,8 @@
 type ServiceType = 'universalQuery'
   | 'verticalQuery'
   | 'universalAutoComplete'
-  | 'verticalAutoComplete';
+  | 'verticalAutoComplete'
+  | 'filterSearch';
 
 type ServiceIds = {
   [key in ServiceType]: number;
@@ -23,14 +24,16 @@ export default class HttpManager {
       universalQuery: 0,
       verticalQuery: 0,
       universalAutoComplete: 0,
-      verticalAutoComplete: 0
+      verticalAutoComplete: 0,
+      filterSearch: 0
     };
 
     this.latestResponseIds = {
       universalQuery: 0,
       verticalQuery: 0,
       universalAutoComplete: 0,
-      verticalAutoComplete: 0
+      verticalAutoComplete: 0,
+      filterSearch: 0
     };
   }
 

--- a/src/models/slices/filtersearch.ts
+++ b/src/models/slices/filtersearch.ts
@@ -1,8 +1,16 @@
-import { FilterSearchResponse } from '@yext/answers-core';
+import { AutocompleteResult, SearchIntent } from '@yext/answers-core';
 
-interface FilterSearchState {
+export interface FilterSearchState {
   query: string,
-  results?: FilterSearchResponse
+  sectioned?: boolean,
+  sections?: {
+    label: string,
+    results: AutocompleteResult[]
+  }[],
+  results?: AutocompleteResult[],
+  searchIntents?: SearchIntent[],
+  queryId?: string,
+  uuid?: string
 }
 
 export interface FilterSearchStates {

--- a/src/models/slices/filtersearch.ts
+++ b/src/models/slices/filtersearch.ts
@@ -1,0 +1,10 @@
+import { FilterSearchResponse } from '@yext/answers-core';
+
+interface FilterSearchState {
+  query: string,
+  results?: FilterSearchResponse
+}
+
+export interface FilterSearchStates {
+  [filterSearchId: string]: FilterSearchState
+}

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -6,6 +6,7 @@ import { SpellCheckState } from './slices/spellcheck';
 import { MetaState } from './slices/meta';
 import { LocationState } from './slices/location';
 import { SessionTrackingState } from './slices/sessiontracking';
+import { FilterSearchStates } from './slices/filtersearch';
 
 /**
  * The overall shape of the redux state tree, with each key value pair
@@ -19,6 +20,7 @@ export interface State {
   query: QueryState,
   universal: UniversalSearchState,
   vertical: VerticalSearchState,
+  filterSearch: FilterSearchStates,
   filters: FiltersState,
   spellCheck: SpellCheckState,
   sessionTracking: SessionTrackingState

--- a/src/slices/filtersearch.ts
+++ b/src/slices/filtersearch.ts
@@ -1,0 +1,40 @@
+import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
+import { FilterSearchResponse } from '@yext/answers-core';
+import { FilterSearchStates } from '../models/slices/filtersearch';
+
+const initialState: FilterSearchStates = {};
+
+const reducers = {
+  setQuery: (
+    state: FilterSearchStates,
+    action: PayloadAction<{ query: string, filterSearchId: string }>
+  ) => {
+    const { filterSearchId, query } = action.payload;
+    if (!filterSearchId) {
+      console.warn(`invalid filterSearch id: "${filterSearchId}"`);
+      return;
+    }
+    state[filterSearchId]
+      ? state[filterSearchId].query = query
+      : state[filterSearchId] = { query };
+  },
+  setResults: (
+    state: FilterSearchStates,
+    action: PayloadAction<{ filterSearchId: string, results: FilterSearchResponse }>
+  ) => {
+    const { filterSearchId, results } = action.payload;
+    state[filterSearchId].results = results;
+  }
+};
+
+/**
+ * Registers with Redux the slice of {@link State} pertaining to filter search. There
+ * are reducers for setting the query and results of the filterSearch.
+ */
+export default function createFilterSearchSlice(prefix: string): Slice<FilterSearchStates, typeof reducers> {
+  return createSlice({
+    name: prefix + 'filterSearch',
+    initialState,
+    reducers
+  });
+}

--- a/src/slices/filtersearch.ts
+++ b/src/slices/filtersearch.ts
@@ -1,6 +1,5 @@
 import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
-import { FilterSearchResponse } from '@yext/answers-core';
-import { FilterSearchStates } from '../models/slices/filtersearch';
+import { FilterSearchState, FilterSearchStates } from '../models/slices/filtersearch';
 
 const initialState: FilterSearchStates = {};
 
@@ -20,10 +19,13 @@ const reducers = {
   },
   setResults: (
     state: FilterSearchStates,
-    action: PayloadAction<{ filterSearchId: string, results: FilterSearchResponse }>
+    action: PayloadAction<{ filterSearchId: string, results: Omit<FilterSearchState, 'query'> }>
   ) => {
     const { filterSearchId, results } = action.payload;
-    state[filterSearchId].results = results;
+    state[filterSearchId] = {
+      query: state[filterSearchId].query,
+      ...results
+    };
   }
 };
 

--- a/src/slices/filtersearch.ts
+++ b/src/slices/filtersearch.ts
@@ -11,7 +11,7 @@ const reducers = {
   ) => {
     const { filterSearchId, query } = action.payload;
     if (!filterSearchId) {
-      console.warn(`invalid filterSearch id: "${filterSearchId}"`);
+      console.warn(`invalid filterSearch id: "${filterSearchId}". Id must be a non-empty string.`);
       return;
     }
     state[filterSearchId]

--- a/src/slices/location.ts
+++ b/src/slices/location.ts
@@ -5,10 +5,10 @@ import { LocationState } from '../models/slices/location';
 const initialState: LocationState = {};
 
 const reducers = {
-  setUserLocation: (state, action: PayloadAction<LatLong>) => {
+  setUserLocation: (state: LocationState, action: PayloadAction<LatLong>) => {
     state.userLocation = action.payload;
   },
-  setLocationBias: (state, action: PayloadAction<LocationBias>) => {
+  setLocationBias: (state: LocationState, action: PayloadAction<LocationBias>) => {
     state.locationBias = action.payload;
   }
 };

--- a/src/slices/meta.ts
+++ b/src/slices/meta.ts
@@ -5,10 +5,10 @@ import { MetaState } from '../models/slices/meta';
 const initialState: MetaState = {};
 
 const reducers = {
-  setContext: (state, action: PayloadAction<Context>) => {
+  setContext: (state: MetaState, action: PayloadAction<Context>) => {
     state.context = action.payload;
   },
-  setReferrerPageUrl: (state, action: PayloadAction<string>) => {
+  setReferrerPageUrl: (state: MetaState, action: PayloadAction<string>) => {
     state.referrerPageUrl = action.payload;
   }
 };

--- a/src/slices/query.ts
+++ b/src/slices/query.ts
@@ -5,22 +5,22 @@ import { QueryState } from '../models/slices/query';
 const initialState: QueryState = {};
 
 const reducers = {
-  set: (state, action: PayloadAction<string>) => {
+  set: (state: QueryState, action: PayloadAction<string>) => {
     state.query = action.payload;
   },
-  setTrigger: (state, action: PayloadAction<QueryTrigger>) => {
+  setTrigger: (state: QueryState, action: PayloadAction<QueryTrigger>) => {
     state.queryTrigger = action.payload;
   },
-  setSource: (state, action: PayloadAction<QuerySource>) => {
+  setSource: (state: QueryState, action: PayloadAction<QuerySource>) => {
     state.querySource = action.payload;
   },
-  setQueryId: (state, action: PayloadAction<string>) => {
+  setQueryId: (state: QueryState, action: PayloadAction<string>) => {
     state.queryId = action.payload;
   },
-  setLatest: (state, action: PayloadAction<string>) => {
+  setLatest: (state: QueryState, action: PayloadAction<string>) => {
     state.latest = action.payload;
   },
-  setSearchIntents: (state, action: PayloadAction<SearchIntent[]>) => {
+  setSearchIntents: (state: QueryState, action: PayloadAction<SearchIntent[]>) => {
     state.searchIntents = action.payload;
   }
 };

--- a/src/slices/sessiontracking.ts
+++ b/src/slices/sessiontracking.ts
@@ -6,10 +6,10 @@ const initialState: SessionTrackingState = {
 };
 
 const reducers = {
-  setEnabled: (state, action: PayloadAction<boolean>) => {
+  setEnabled: (state: SessionTrackingState, action: PayloadAction<boolean>) => {
     state.enabled = action.payload;
   },
-  setSessionId: (state, action: PayloadAction<string>) => {
+  setSessionId: (state: SessionTrackingState, action: PayloadAction<string>) => {
     state.sessionId = action.payload;
   },
 };

--- a/src/slices/spellcheck.ts
+++ b/src/slices/spellcheck.ts
@@ -7,13 +7,13 @@ const initialState: SpellCheckState = {
 };
 
 const reducers = {
-  setResult: (state, action: PayloadAction<SpellCheck>) => {
+  setResult: (state: SpellCheckState, action: PayloadAction<SpellCheck>) => {
     return {
       enabled: state.enabled,
       ...action.payload
     };
   },
-  setEnabled: (state, action: PayloadAction<boolean>) => {
+  setEnabled: (state: SpellCheckState, action: PayloadAction<boolean>) => {
     state.enabled = action.payload;
   },
 };

--- a/src/slices/universal.ts
+++ b/src/slices/universal.ts
@@ -5,16 +5,16 @@ import { UniversalSearchState } from '../models/slices/universal';
 const initialState: UniversalSearchState = {};
 
 const reducers = {
-  setResults: (state, action: PayloadAction<UniversalSearchResponse>) => {
+  setResults: (state: UniversalSearchState, action: PayloadAction<UniversalSearchResponse>) => {
     state.results = action.payload;
   },
-  setAutoComplete: (state, action: PayloadAction<AutocompleteResponse>) => {
+  setAutoComplete: (state: UniversalSearchState, action: PayloadAction<AutocompleteResponse>) => {
     state.autoComplete = action.payload;
   },
-  setSearchLoading: (state, action: PayloadAction<boolean>) => {
+  setSearchLoading: (state: UniversalSearchState, action: PayloadAction<boolean>) => {
     state.searchLoading = action.payload;
   },
-  setLimit: (state, action: PayloadAction<UniversalLimit>) => {
+  setLimit: (state: UniversalSearchState, action: PayloadAction<UniversalLimit>) => {
     state.limit = action.payload;
   },
 };

--- a/src/slices/vertical.ts
+++ b/src/slices/vertical.ts
@@ -5,28 +5,28 @@ import { VerticalSearchState } from '../models/slices/vertical';
 const initialState: VerticalSearchState = {};
 
 const reducers = {
-  setKey: (state, action: PayloadAction<string>) => {
+  setKey: (state: VerticalSearchState, action: PayloadAction<string>) => {
     state.key = action.payload;
   },
-  setResults: (state, action: PayloadAction<VerticalSearchResponse>) => {
+  setResults: (state: VerticalSearchState, action: PayloadAction<VerticalSearchResponse>) => {
     state.results = action.payload;
   },
-  setAutoComplete: (state, action: PayloadAction<AutocompleteResponse>) => {
+  setAutoComplete: (state: VerticalSearchState, action: PayloadAction<AutocompleteResponse>) => {
     state.autoComplete = action.payload;
   },
-  setAlternativeVerticals: (state, action: PayloadAction<VerticalResults[]>) => {
+  setAlternativeVerticals: (state: VerticalSearchState, action: PayloadAction<VerticalResults[]>) => {
     state.alternativeVerticals = action.payload;
   },
-  setDisplayName: (state, action: PayloadAction<string>) => {
+  setDisplayName: (state: VerticalSearchState, action: PayloadAction<string>) => {
     state.displayName = action.payload;
   },
-  setLimit: (state, action: PayloadAction<number>) => {
+  setLimit: (state: VerticalSearchState, action: PayloadAction<number>) => {
     state.limit = action.payload;
   },
-  setOffset: (state, action: PayloadAction<number>) => {
+  setOffset: (state: VerticalSearchState, action: PayloadAction<number>) => {
     state.offset = action.payload;
   },
-  setSearchLoading: (state, action: PayloadAction<boolean>) => {
+  setSearchLoading: (state: VerticalSearchState, action: PayloadAction<boolean>) => {
     state.searchLoading = action.payload;
   }
 };

--- a/tests/integration/query.ts
+++ b/tests/integration/query.ts
@@ -222,14 +222,14 @@ describe('ensure correct results from latest request', () => {
 
     jest.advanceTimersByTime(requestsTime[queries[1]]);
     await secondResponsePromise;
-    expect(answers.state.filterSearch[filterSearchId].results.results).toEqual([{ value: queries[1] }]);
+    expect(answers.state.filterSearch[filterSearchId].results).toEqual([{ value: queries[1] }]);
     jest.advanceTimersByTime(requestsTime[queries[2]]);
     await thirdResponsePromise;
     jest.runAllTimers();
     await firstResponsePromise;
 
     expect(answers.state.filterSearch[filterSearchId].query).toEqual(queries[2]);
-    expect(answers.state.filterSearch[filterSearchId].results.results).toEqual([{ value: queries[2] }]);
+    expect(answers.state.filterSearch[filterSearchId].results).toEqual([{ value: queries[2] }]);
     expect(updateResult.mock.calls).toHaveLength(2);
   });
 });

--- a/tests/mocks/expectedInitialState.ts
+++ b/tests/mocks/expectedInitialState.ts
@@ -12,5 +12,6 @@ export const expectedInitialState: State = {
     enabled: true
   },
   universal: {},
-  vertical: {}
+  vertical: {},
+  filterSearch: {}
 };

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -378,13 +378,28 @@ describe('search works as expected', () => {
       consoleErrorSpy.mockClear();
     });
 
+    it('execute filter search with empty string for filterSearchId', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      await answers.executeFilterSearch('', false, fields);
+      expect(mockedCore.filterSearch).toHaveBeenCalledTimes(0);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenLastCalledWith(
+        expect.stringContaining('Unable to execute filter search. ' +
+        'invalid filterSearch id: "". Id must be a non-empty string.'
+        )
+      );
+      consoleErrorSpy.mockClear();
+    });
+
     it('execute filter search with invalid filterSearchId', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       await answers.executeFilterSearch('invalidId', false, fields);
       expect(mockedCore.filterSearch).toHaveBeenCalledTimes(0);
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
       expect(consoleErrorSpy).toHaveBeenLastCalledWith(
-        expect.stringContaining('invalid filterSearch id: "invalidId"')
+        expect.stringContaining('Unable to execute filter search. ' +
+        'The following filterSearch id does not exist in state: "invalidId"'
+        )
       );
       consoleErrorSpy.mockClear();
     });

--- a/tests/unit/slices/filtersearch.ts
+++ b/tests/unit/slices/filtersearch.ts
@@ -1,0 +1,80 @@
+import createFilterSearchSlice from '../../../src/slices/filtersearch';
+
+const { actions, reducer } = createFilterSearchSlice('');
+const { setQuery, setResults } = actions;
+
+describe('filter slice reducer works as expected', () => {
+  it('setQuery action is handled properly with invalid filterSearchId', () => {
+    const filterSearchQuery = {
+      query: 'someQuery',
+      filterSearchId: ''
+    };
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const actualState = reducer({}, setQuery(filterSearchQuery));
+    expect(actualState).toEqual({});
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
+      expect.stringContaining('invalid filterSearch id')
+    );
+    consoleWarnSpy.mockClear();
+  });
+
+  it('setQuery action is handled properly with new unregistered filterSearchId', () => {
+    const filterSearchQuery = {
+      query: 'someQuery',
+      filterSearchId: 'newId'
+    };
+    const actualState = reducer({}, setQuery(filterSearchQuery));
+    const expectedState = {
+      newId: {
+        query: filterSearchQuery.query
+      }
+    };
+    expect(actualState).toEqual(expectedState);
+  });
+
+  it('setQuery action is handled properly with registered filterSearchId', () => {
+    const filterSearchQuery = {
+      query: 'someQuery',
+      filterSearchId: 'someId'
+    };
+    const initialState = {
+      someId: {
+        query: 'previousQuery'
+      }
+    };
+    const actualState = reducer(initialState, setQuery(filterSearchQuery));
+    const expectedState = {
+      someId: {
+        query: filterSearchQuery.query
+      }
+    };
+    expect(actualState).toEqual(expectedState);
+  });
+
+  it('setResults action is handled properly', () => {
+    const filterSearchResults = {
+      filterSearchId: 'someId',
+      results: {
+        sectioned: true,
+        sections: [],
+        results: [],
+        inputIntents: [],
+        uuid: ''
+      }
+    };
+    const initialState = {
+      someId: {
+        query: 'previousQuery'
+      }
+    };
+    const actualState = reducer(initialState, setResults(filterSearchResults));
+    const expectedState = {
+      someId: {
+        query: initialState.someId.query,
+        results: filterSearchResults.results
+      }
+    };
+    expect(actualState).toEqual(expectedState);
+  });
+});

--- a/tests/unit/slices/filtersearch.ts
+++ b/tests/unit/slices/filtersearch.ts
@@ -72,7 +72,7 @@ describe('filter slice reducer works as expected', () => {
     const expectedState = {
       someId: {
         query: initialState.someId.query,
-        results: filterSearchResults.results
+        ...filterSearchResults.results
       }
     };
     expect(actualState).toEqual(expectedState);


### PR DESCRIPTION
Add support for filterSearch data in state

- added filterSearch following interface `FilterSearchStates` to top level `State`, which contains a mapping of filterSearchId to `FilterSearchState` with query and results field. This is to support multiple filter search components
- add `setFilterSearchQuery` as part of headless public interface. Update `executeFilterSearch` to store results in state, and maintain correct response order
- added reducers
- added more typing, and tests

the flow for React component would be: use `setFilterSearchQuery` to update the input value of each filterSearch component, `executeFilterSearch` on submit, and call `toggleFilterOption` to add the selected filter for a specific filterSearch component from the list of filterSearch results.

J=SLAP-1685
TEST=auto

see that jest test passed