### PR TITLE
Remove ID from staticFilter state

### DIFF
--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -298,10 +298,9 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('filters/toggleFacetOption', payload);
   }
 
-  setFilterOption(seletableFilter: SelectableFilter, filterCollectionId: string): void {
+  setFilterOption(seletableFilter: SelectableFilter): void {
     const { selected, ...filter } = seletableFilter;
     const payload = {
-      filterCollectionId,
       filter: filter,
       shouldSelect: selected
     };

--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -2,9 +2,7 @@ import { DisplayableFacet, SortBy } from '@yext/answers-core';
 import { SelectableFilter } from '../utils/selectablefilter';
 
 export interface FiltersState {
-  static?: {
-   [filterCollectionId: string]: SelectableFilter[];
-  }
+  static?: SelectableFilter[];
   facets?: DisplayableFacet[];
   sortBys?: SortBy[]
 }

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { Filter, FacetOption, DisplayableFacet, SortBy } from '@yext/answers-core';
 import { FiltersState } from '../models/slices/filters';
 import { SelectableFilter } from '../models/utils/selectablefilter';
+import { areFiltersEqual } from '../utils/filter-utils';
 
 const initialState: FiltersState = {};
 
@@ -61,14 +62,12 @@ const reducers = {
       state.static = [];
     }
     const { filter: targetFilter, shouldSelect } = payload;
-    const foundFilter = state.static.find(storedSelectableFilter => {
+    const matchedFilter = state.static.find(storedSelectableFilter => {
       const { selected:_, ...storedFilter } = storedSelectableFilter;
-      return storedFilter.fieldId === targetFilter.fieldId
-        && storedFilter.matcher === targetFilter.matcher
-        && storedFilter.value === targetFilter.value;
+      return areFiltersEqual(storedFilter, targetFilter);
     });
-    if (foundFilter) {
-      foundFilter.selected = shouldSelect;
+    if (matchedFilter) {
+      matchedFilter.selected = shouldSelect;
     } else if (shouldSelect) {
       const selectedFilter = { ...targetFilter, selected: shouldSelect };
       state.static.push(selectedFilter);

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -62,12 +62,12 @@ const reducers = {
       state.static = [];
     }
     const { filter: targetFilter, shouldSelect } = payload;
-    const matchedFilter = state.static.find(storedSelectableFilter => {
+    const matchingFilter = state.static.find(storedSelectableFilter => {
       const { selected:_, ...storedFilter } = storedSelectableFilter;
       return areFiltersEqual(storedFilter, targetFilter);
     });
-    if (matchedFilter) {
-      matchedFilter.selected = shouldSelect;
+    if (matchingFilter) {
+      matchingFilter.selected = shouldSelect;
     } else if (shouldSelect) {
       const selectedFilter = { ...targetFilter, selected: shouldSelect };
       state.static.push(selectedFilter);

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -12,7 +12,6 @@ interface FacetPayload {
 }
 
 interface FilterPayload {
-  filterCollectionId: string
   filter: Filter
   shouldSelect: boolean
 }
@@ -20,7 +19,7 @@ interface FilterPayload {
 const reducers = {
   setStatic: (
     state: FiltersState,
-    action: PayloadAction<Record<string, SelectableFilter[]>>
+    action: PayloadAction<SelectableFilter[]>
   ) => {
     state.static = action.payload;
   },
@@ -59,15 +58,10 @@ const reducers = {
   },
   setFilterOption: (state: FiltersState, { payload }: PayloadAction<FilterPayload>) => {
     if (!state.static) {
-      state.static = {};
+      state.static = [];
     }
-    const { filterCollectionId, filter: targetFilter, shouldSelect } = payload;
-    if (!filterCollectionId) {
-      console.warn(`invalid static filters id: ${filterCollectionId}`);
-      return;
-    }
-    const filterCollection = state.static[filterCollectionId];
-    const foundFilter = filterCollection?.find(storedSelectableFilter => {
+    const { filter: targetFilter, shouldSelect } = payload;
+    const foundFilter = state.static.find(storedSelectableFilter => {
       const { selected:_, ...storedFilter } = storedSelectableFilter;
       return storedFilter.fieldId === targetFilter.fieldId
         && storedFilter.matcher === targetFilter.matcher
@@ -77,12 +71,10 @@ const reducers = {
       foundFilter.selected = shouldSelect;
     } else if (shouldSelect) {
       const selectedFilter = { ...targetFilter, selected: shouldSelect };
-      filterCollection
-        ? filterCollection.push(selectedFilter)
-        : state.static[filterCollectionId] = [selectedFilter];
+      state.static.push(selectedFilter);
     } else {
-      console.warn('Could not unselect a non-existing filter option in state from filterCollectionId: '
-        + `'${filterCollectionId}' with the following fields:\n${JSON.stringify(targetFilter)}.`);
+      console.warn('Could not unselect a non-existing filter option in state '
+        + `with the following fields:\n${JSON.stringify(targetFilter)}.`);
     }
   }
 };

--- a/src/utils/filter-utils.ts
+++ b/src/utils/filter-utils.ts
@@ -1,0 +1,10 @@
+import { Filter } from '@yext/answers-core';
+
+/**
+ * Returns true if the two given filters are the same
+ */
+export function areFiltersEqual(thisFilter: Filter, otherFilter: Filter): boolean {
+  return thisFilter.fieldId === otherFilter.fieldId
+  && thisFilter.matcher === otherFilter.matcher
+  && thisFilter.value === otherFilter.value;
+}

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -3,8 +3,9 @@ import HttpManager from '../../src/http-manager';
 import StateManager from '../../src/models/state-manager';
 import AnswersHeadless from '../../src/answers-headless';
 import { SelectableFilter } from '../../src/models/utils/selectablefilter';
+import { State } from '../../src/models/state';
 
-const mockedState = {
+const mockedState: State = {
   query: {
     query: 'Search',
     querySource: QuerySource.Standard,
@@ -17,16 +18,12 @@ const mockedState = {
     limit: 20
   },
   filters: {
-    static: {
-      someId: [
-        {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value',
-          selected: true
-        }
-      ]
-    }
+    static: [{
+      fieldId: 'c_someField',
+      matcher: Matcher.Equals,
+      value: 'some value',
+      selected: true
+    }]
   },
   spellCheck: {
     enabled: true
@@ -36,7 +33,8 @@ const mockedState = {
     sessionId: 'random-id-number'
   },
   meta: {},
-  location: {}
+  location: {},
+  directAnswer: {}
 };
 
 const mockedStateManager: jest.Mocked<StateManager> = {
@@ -245,14 +243,13 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.setFilterOption({ ...filter, selected: true }, 'someId');
+    answers.setFilterOption({ ...filter, selected: true });
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
     expect(dispatchEventCalls[0][0]).toBe('filters/setFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: true,
-      filterCollectionId: 'someId',
       filter: filter
     });
   });
@@ -263,14 +260,13 @@ describe('filter functions work as expected', () => {
       matcher: Matcher.Equals,
       value: 'someValue'
     };
-    answers.setFilterOption({ ...filter, selected: false }, 'someId');
+    answers.setFilterOption({ ...filter, selected: false });
     const dispatchEventCalls =
     mockedStateManager.dispatchEvent.mock.calls;
     expect(dispatchEventCalls.length).toBe(1);
     expect(dispatchEventCalls[0][0]).toBe('filters/setFilterOption');
     expect(dispatchEventCalls[0][1]).toEqual({
       shouldSelect: false,
-      filterCollectionId: 'someId',
       filter: filter
     });
   });
@@ -320,7 +316,7 @@ describe('search works as expected', () => {
 
   it('vertical search works', async () => {
     await answers.executeVerticalQuery();
-    const { selected:_, ...filter } = mockedState.filters.static.someId[0];
+    const { selected:_, ...filter } = mockedState.filters.static[0];
     const coreCalls = mockedCore.verticalSearch.mock.calls;
     const expectedSearchParams = {
       ...mockedState.query,

--- a/tests/unit/slices/filters.ts
+++ b/tests/unit/slices/filters.ts
@@ -19,34 +19,30 @@ describe('filter slice reducer works as expected', () => {
   };
 
   const initialState = {
-    static: {
-      someId: [
-        {
-          fieldId: 'id1',
-          matcher: Matcher.Equals,
-          value: 'value1',
-          selected: true
-        },
-        {
-          fieldId: 'id2',
-          matcher: Matcher.Equals,
-          value: 'value2',
-          selected: true
-        },
-        {
-          fieldId: 'id3',
-          matcher: Matcher.Equals,
-          value: 'value3',
-          selected: false
-        }
-      ]
-    }
+    static: [
+      {
+        fieldId: 'id1',
+        matcher: Matcher.Equals,
+        value: 'value1',
+        selected: true
+      },
+      {
+        fieldId: 'id2',
+        matcher: Matcher.Equals,
+        value: 'value2',
+        selected: true
+      },
+      {
+        fieldId: 'id3',
+        matcher: Matcher.Equals,
+        value: 'value3',
+        selected: false
+      }
+    ]
   };
 
   it('setStatic action is handled properly', () => {
-    const staticFilter = {
-      someId: [selectableFilter]
-    };
+    const staticFilter = [selectableFilter];
     const actualState = reducer({}, setStatic(staticFilter));
     const expectedState = {
       static: staticFilter
@@ -57,7 +53,6 @@ describe('filter slice reducer works as expected', () => {
 
   it('setFilterOption action is handled properly with no static state', () => {
     const unselectFilterPayload = {
-      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -68,80 +63,18 @@ describe('filter slice reducer works as expected', () => {
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const actualState = reducer({}, setFilterOption(unselectFilterPayload));
     const expectedState = {
-      static: {
-        someId: [{
-          ...unselectFilterPayload.filter,
-          selected: true
-        }]
-      }
+      static: [{
+        ...unselectFilterPayload.filter,
+        selected: true
+      }]
     };
     expect(actualState).toEqual(expectedState);
     expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
     consoleWarnSpy.mockClear();
   });
 
-  it('setFilterOption action is handled properly with unknown filterCollectionId on unselect', () => {
+  it('setFilterOption action is handled properly with existing filters', () => {
     const unselectFilterPayload = {
-      filterCollectionId: 'invalidId',
-      filter: {
-        fieldId: 'id2',
-        matcher: Matcher.Equals,
-        value: 'value2'
-      },
-      shouldSelect: false
-    };
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, setFilterOption(unselectFilterPayload));
-    expect(actualState).toEqual(initialState);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-      expect.stringContaining('Could not unselect a non-existing filter option in state')
-    );
-    consoleWarnSpy.mockClear();
-  });
-
-  it('setFilterOption action is handled properly with unknown filterCollectionId on select', () => {
-    const selectFilterPayload = {
-      filterCollectionId: 'newId',
-      filter: {
-        fieldId: 'id2',
-        matcher: Matcher.Equals,
-        value: 'value2'
-      },
-      shouldSelect: true
-    };
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
-    const selectExpectedState = _.cloneDeep(initialState);
-    selectExpectedState.static['newId'] = [{ ...selectFilterPayload.filter, selected: true }];
-    expect(actualState).toEqual(selectExpectedState);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(0);
-    consoleWarnSpy.mockClear();
-  });
-
-  it('setFilterOption action is handled properly with empty string for filterCollectionId', () => {
-    const selectFilterPayload = {
-      filterCollectionId: '',
-      filter: {
-        fieldId: 'id2',
-        matcher: Matcher.Equals,
-        value: 'value2'
-      },
-      shouldSelect: true
-    };
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
-    expect(actualState).toEqual(initialState);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy).toHaveBeenLastCalledWith(
-      expect.stringContaining('invalid static filters id')
-    );
-    consoleWarnSpy.mockClear();
-  });
-
-  it('setFilterOption action is handled properly, with valid filterCollectionId', () => {
-    const unselectFilterPayload = {
-      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id2',
         matcher: Matcher.Equals,
@@ -151,7 +84,6 @@ describe('filter slice reducer works as expected', () => {
     };
 
     const selectFilterPayload = {
-      filterCollectionId: 'someId',
       filter: {
         fieldId: 'id3',
         matcher: Matcher.Equals,
@@ -162,18 +94,17 @@ describe('filter slice reducer works as expected', () => {
 
     let actualState = reducer(initialState, setFilterOption(unselectFilterPayload));
     const unselectExpectedState = _.cloneDeep(initialState);
-    unselectExpectedState.static.someId[1].selected = false;
+    unselectExpectedState.static[1].selected = false;
     expect(actualState).toEqual(unselectExpectedState);
 
     actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     const selectedExpectedState = _.cloneDeep(initialState);
-    selectedExpectedState.static.someId[2].selected = true;
+    selectedExpectedState.static[2].selected = true;
     expect(actualState).toEqual(selectedExpectedState);
   });
 
   it('setFilterOption action is handled properly with filter not found in state when select', () => {
     const selectFilterPayload = {
-      filterCollectionId: 'someId',
       filter: {
         fieldId: 'invalid field',
         matcher: Matcher.Equals,
@@ -183,7 +114,7 @@ describe('filter slice reducer works as expected', () => {
     };
     const actualState = reducer(initialState, setFilterOption(selectFilterPayload));
     const selectedExpectedState = _.cloneDeep(initialState);
-    selectedExpectedState.static.someId.push({
+    selectedExpectedState.static.push({
       ...selectFilterPayload.filter,
       selected: true
     });
@@ -192,7 +123,6 @@ describe('filter slice reducer works as expected', () => {
 
   it('setFilterOption action is handled properly with filter not found in state when unselect', () => {
     const unselectFilterPayload = {
-      filterCollectionId: 'someId',
       filter: {
         fieldId: 'invalid field',
         matcher: Matcher.Equals,

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -3,31 +3,29 @@ import { SelectableFilter } from '../../../src/models/utils/selectablefilter';
 import { transformFiltersToCoreFormat } from '../../../src/utils/transform-filters';
 
 describe('see that transformFiltersToCoreFormat works properly', () => {
-  it('properly handle an undefined filter', () => {
+  it('properly handle an undefined or no filter', () => {
     let transformedFilter = transformFiltersToCoreFormat(undefined);
     expect(transformedFilter).toEqual(null);
 
-    transformedFilter = transformFiltersToCoreFormat({someId: []});
+    transformedFilter = transformFiltersToCoreFormat([]);
     expect(transformedFilter).toEqual(null);
   });
 
   it('properly handle a selected Filter', () => {
-    const filters: Record<string, SelectableFilter[]> = {
-      someId: [
-        {
-          fieldId: 'c_someField',
-          matcher: Matcher.Equals,
-          value: 'some value',
-          selected: true
-        }
-      ]
-    };
+    const selectableFilters: SelectableFilter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value',
+        selected: true
+      }
+    ];
     const expectedFilters = {
       fieldId: 'c_someField',
       matcher: Matcher.Equals,
       value: 'some value'
     };
-    const transformedFilter = transformFiltersToCoreFormat(filters);
+    const transformedFilter = transformFiltersToCoreFormat(selectableFilters);
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
@@ -41,9 +39,7 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
       ...filter,
       selected: true
     };
-    const filters: Record<string, SelectableFilter[]> = {
-      someId: [selectableFilter, selectableFilter, selectableFilter]
-    };
+    const filters: SelectableFilter[] = [selectableFilter, selectableFilter, selectableFilter];
     const expectedFilters = {
       combinator: FilterCombinator.OR,
       filters: [filter, filter, filter]
@@ -94,9 +90,7 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
         selected: true
       }
     ];
-    const filterCollections = {
-      someId: selectableFilters
-    };
+
     const expectedFilters: Filter | CombinedFilter = {
       combinator: FilterCombinator.AND,
       filters: [
@@ -110,7 +104,7 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
         }
       ]
     };
-    const transformedFilter = transformFiltersToCoreFormat(filterCollections);
+    const transformedFilter = transformFiltersToCoreFormat(selectableFilters);
     expect(transformedFilter).toEqual(expectedFilters);
   });
 
@@ -156,99 +150,11 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
         selected: true
       }
     ];
-    const filterCollections = {
-      someId: selectableFilters
-    };
     const expectedFilters: Filter | CombinedFilter = {
       combinator: FilterCombinator.AND,
       filters: [filters[2], filters[3]]
     };
-    const transformedFilter = transformFiltersToCoreFormat(filterCollections);
-    expect(transformedFilter).toEqual(expectedFilters);
-  });
-
-  it('properly handle selected filters of different groups with different filterCollectionIds', () => {
-    const someIdfilters: Filter[] = [
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'some value'
-      },
-      {
-        fieldId: 'c_someField',
-        matcher: Matcher.Equals,
-        value: 'unique value'
-      },
-      {
-        fieldId: 'c_aDifferentField',
-        matcher: Matcher.Equals,
-        value: 'very unique value'
-      }
-    ];
-
-    const someIdSelectableFilters: SelectableFilter[] = [
-      {
-        ...someIdfilters[0],
-        selected: true
-      },
-      {
-        ...someIdfilters[1],
-        selected: true
-      },
-      {
-        ...someIdfilters[2],
-        selected: true
-      }
-    ];
-
-    const anotherIdfilters: Filter[] = [
-      {
-        fieldId: 'c_anotherField',
-        matcher: Matcher.Equals,
-        value: 'another value'
-      },
-      {
-        fieldId: 'c_anotherField',
-        matcher: Matcher.Equals,
-        value: 'unique value'
-      }
-    ];
-
-    const anotherIdSelectableFilters: SelectableFilter[] = [
-      {
-        ...anotherIdfilters[0],
-        selected: true
-      },
-      {
-        ...anotherIdfilters[1],
-        selected: true
-      }
-    ];
-
-    const filters = {
-      someId: someIdSelectableFilters,
-      anotherId: anotherIdSelectableFilters
-    };
-    const expectedFilters: Filter | CombinedFilter = {
-      combinator: FilterCombinator.AND,
-      filters: [
-        {
-          combinator: FilterCombinator.AND,
-          filters: [
-            {
-              combinator: FilterCombinator.OR,
-              filters: [someIdfilters[0], someIdfilters[1]]
-            },
-            someIdfilters[2]
-          ]
-        },
-        {
-          combinator: FilterCombinator.OR,
-          filters: [anotherIdfilters[0], anotherIdfilters[1]]
-        }
-      ]
-    };
-    const transformedFilter = transformFiltersToCoreFormat(filters);
+    const transformedFilter = transformFiltersToCoreFormat(selectableFilters);
     expect(transformedFilter).toEqual(expectedFilters);
   });
 });


### PR DESCRIPTION
update StaticFilter to not use ids to manage multiple filters. Instead, all multiple filters are grouped into one array. The merging process for filters (AND/OR) will remain in headless, as discussed with product.

- remove mapping from FilterState, replace by list of SelectableFilter
- update public interface to remove filterCollectionId
- update transformFiltersToCoreFormat to be from list of SelectableFilter, instead of a mapping of id to filters, to the nested structure for core
- update jest tests


J=SLAP-1688
TEST=manual&auto

- see that updated jest tests passed
- hook to sample app, see that multiple static filters still work