### PR TITLE
update executeFilterSearch to take in an input

### DIFF
--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -270,11 +270,11 @@ export default class AnswersHeadless {
     return results;
   }
 
-  executeFilterSearch(
+  async executeFilterSearch(
     query: string,
     sectioned: boolean,
     fields: SearchParameterField[]
-  ): Promise<FilterSearchResponse> {
+  ): Promise<FilterSearchResponse | undefined> {
     const verticalKey = this.state.vertical.key;
     if (!verticalKey) {
       console.error('no verticalKey supplied for filter search');

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -270,10 +270,19 @@ export default class AnswersHeadless {
     return results;
   }
 
-  executeFilterSearch(sectioned: boolean, fields: SearchParameterField[]): Promise<FilterSearchResponse> {
+  executeFilterSearch(
+    query: string,
+    sectioned: boolean,
+    fields: SearchParameterField[]
+  ): Promise<FilterSearchResponse> {
+    const verticalKey = this.state.vertical.key;
+    if (!verticalKey) {
+      console.error('no verticalKey supplied for filter search');
+      return;
+    }
     return this.core.filterSearch({
-      input: this.state.query.query || '',
-      verticalKey: this.state.vertical.key || '',
+      input: query,
+      verticalKey,
       sessionTrackingEnabled: this.state.sessionTracking.enabled,
       sectioned,
       fields

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -345,11 +345,11 @@ describe('search works as expected', () => {
         fetchEntities: false
       }
     ];
-    await answers.executeFilterSearch(false, fields);
+    await answers.executeFilterSearch('someInput', false, fields);
 
     expect(mockedCore.filterSearch).toHaveBeenCalledTimes(1);
     expect(mockedCore.filterSearch).toHaveBeenCalledWith({
-      input: 'Search',
+      input: 'someInput',
       verticalKey: 'someKey',
       sessionTrackingEnabled: true,
       sectioned: false,


### PR DESCRIPTION
- update params of `executeFilterSearch` to take in a query instead of using the query store in QueryState

J=SLAP-1685
TEST=auto

- see jest test pass