### PR TITLE
Update setStaticFilters and verticalResults searchloading

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -63,7 +63,7 @@ SOFTWARE.
 The following NPM packages may be included in this product:
 
  - @yext/answers-core@1.3.2
- - @yext/answers-headless@0.1.0-beta.3
+ - @yext/answers-headless@0.1.0-beta.4
 
 These packages each contain the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "0.1.0-beta.3",
+      "version": "0.1.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -64,7 +64,7 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('vertical/setOffset', offset);
   }
 
-  setStaticFilters(filters: Record<string, SelectableFilter[]> | null): void {
+  setStaticFilters(filters: SelectableFilter[]): void {
     this.stateManager.dispatchEvent('filters/setStatic', filters);
   }
 

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -227,7 +227,6 @@ export default class AnswersHeadless {
     this.stateManager.dispatchEvent('query/setMostRecentSearch', input);
     this.stateManager.dispatchEvent('filters/setFacets', response.facets);
     this.stateManager.dispatchEvent('spellCheck/setResult', response.spellCheck);
-    this.stateManager.dispatchEvent('location/setLocationBias', response.locationBias);
     this.stateManager.dispatchEvent('query/setSearchIntents', response.searchIntents || []);
     this.stateManager.dispatchEvent('location/setLocationBias', response.locationBias);
     this.stateManager.dispatchEvent('directAnswer/setResult', response.directAnswer);

--- a/src/models/slices/universal.ts
+++ b/src/models/slices/universal.ts
@@ -2,6 +2,5 @@ import { UniversalLimit, VerticalResults } from '@yext/answers-core';
 
 export interface UniversalSearchState {
   limit?: UniversalLimit,
-  verticals?: VerticalResults[],
-  searchLoading?: boolean
+  verticals?: VerticalResults[]
 }

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -67,9 +67,7 @@ describe('setters work as expected', () => {
       value: 'someValue',
       selected: true
     };
-    const staticFilter = {
-      someId: [filter]
-    };
+    const staticFilter = [filter];
     answers.setStaticFilters(staticFilter);
 
     const dispatchEventCalls =


### PR DESCRIPTION
- bump version
- update setStaticFilters to remove the use of ids
- remove searchLoading from universal state
- remove duplicate locationBias dispatch call

TEST=auto
jest test, and ran sample app with local headless changes