### PR TITLE
Add setQuerySearchIntents to answers-headless interface

### DIFF
--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -12,6 +12,7 @@ import {
   SortBy,
   Context,
   LatLong,
+  SearchIntent,
   SearchParameterField,
   FilterSearchResponse,
   UniversalLimit,
@@ -46,6 +47,10 @@ export default class AnswersHeadless {
 
   setQuerySource(source: QuerySource): void {
     this.stateManager.dispatchEvent('query/setSource', source);
+  }
+
+  setQuerySearchIntents(searchIntents: SearchIntent[]): void {
+    this.stateManager.dispatchEvent('query/setSearchIntents', searchIntents);
   }
 
   setVerticalKey(verticalKey: string): void {

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -1,4 +1,4 @@
-import { Matcher, QuerySource, QueryTrigger } from '@yext/answers-core';
+import { Matcher, QuerySource, QueryTrigger, SearchIntent } from '@yext/answers-core';
 import HttpManager from '../../src/http-manager';
 import StateManager from '../../src/models/state-manager';
 import AnswersHeadless from '../../src/answers-headless';
@@ -165,6 +165,17 @@ describe('setters work as expected', () => {
     expect(dispatchEventCalls.length).toBe(1);
     expect(dispatchEventCalls[0][0]).toBe('query/setSource');
     expect(dispatchEventCalls[0][1]).toBe(QuerySource.Overlay);
+  });
+
+  it('setQuerySearchIntents works as expected', () => {
+    answers.setQuerySearchIntents([SearchIntent.NearMe]);
+
+    const dispatchEventCalls =
+      mockedStateManager.dispatchEvent.mock.calls;
+
+    expect(dispatchEventCalls.length).toBe(1);
+    expect(dispatchEventCalls[0][0]).toBe('query/setSearchIntents');
+    expect(dispatchEventCalls[0][1]).toEqual([SearchIntent.NearMe]);
   });
 
   it('setVerticalKey works as expected', () => {

--- a/tests/unit/slices/query.ts
+++ b/tests/unit/slices/query.ts
@@ -1,8 +1,8 @@
-import { QuerySource, QueryTrigger } from '@yext/answers-core';
+import { QuerySource, QueryTrigger, SearchIntent } from '@yext/answers-core';
 import createQuerySlice from '../../../src/slices/query';
 
 const { reducer, actions } = createQuerySlice('');
-const { setInput, setQueryId, setSource, setTrigger } = actions;
+const { setInput, setQueryId, setSource, setTrigger, setSearchIntents } = actions;
 
 describe('query slice reducer works as expected', () => {
   it('setQuery action is handled properly', () => {
@@ -33,6 +33,14 @@ describe('query slice reducer works as expected', () => {
     const queryId = 'some-id';
     const expectedState = { queryId };
     const actualState = reducer({}, setQueryId(queryId));
+
+    expect(actualState).toEqual(expectedState);
+  });
+
+  it('setSearchIntents action is handled properly', () => {
+    const searchIntents = [SearchIntent.NearMe];
+    const expectedState = { searchIntents };
+    const actualState = reducer({}, setSearchIntents(searchIntents));
 
     expect(actualState).toEqual(expectedState);
   });


### PR DESCRIPTION
- supporting 'near me' in searchbar requires changes to searchIntents before executing a search. Added `setQuerySearchIntents` to headless public interface to allow direct change.

J=SLAP-1706
TEST=auto

see jest tests passed