### PR TITLE
Fix bug that prevented a single Filter from being unselected.

### DIFF
--- a/src/utils/transform-filters.ts
+++ b/src/utils/transform-filters.ts
@@ -28,8 +28,8 @@ export function transformFiltersToCoreFormat(
     return null;
   }
   if (selectableFilters.length === 1) {
-    const { selected:_, ...filter } = selectableFilters[0];
-    return filter;
+    const { selected, ...filter } = selectableFilters[0];
+    return selected ? filter : null;
   }
   const selectedFilters = selectableFilters.filter(selectableFilter => selectableFilter.selected);
   const groupedFilters: Record<string, Filter[]> = selectedFilters.reduce((groups, element) => {

--- a/tests/unit/utils/transform-filters.ts
+++ b/tests/unit/utils/transform-filters.ts
@@ -11,6 +11,19 @@ describe('see that transformFiltersToCoreFormat works properly', () => {
     expect(transformedFilter).toEqual(null);
   });
 
+  it('properly handle an unselected Filter', () => {
+    const selectableFilters: SelectableFilter[] = [
+      {
+        fieldId: 'c_someField',
+        matcher: Matcher.Equals,
+        value: 'some value',
+        selected: false
+      }
+    ];
+    const transformedFilter = transformFiltersToCoreFormat(selectableFilters);
+    expect(transformedFilter).toEqual(null);
+  });
+
   it('properly handle a selected Filter', () => {
     const selectableFilters: SelectableFilter[] = [
       {


### PR DESCRIPTION
I noticed that when a single Filter was selected and I attempted to unselect it, it was still applied to the search. I tracked down the cause of this issue to the `transformFiltersToCoreFormat` method. This method incorrectly assumes that if the list of `SelectableFilter`s is length 1, the filter must be selected. That is not the case, we still need to check the `selected` prop.

TEST=auto

I added a unit test to prevent any regressions.