### PR TITLE
Update remove repo license script

### DIFF
--- a/scripts/remove-repo-license.js
+++ b/scripts/remove-repo-license.js
@@ -44,7 +44,7 @@ function countNumPackagesWithSharedLicense(fileContents, licenseStart) {
  * @returns {string}
  */
 function getNoticesWithoutRepoLicense(fileContents) {
-  const repoLine = ` - ${packageJson.name}`;
+  const repoLine = ` - ${packageJson.name}@${packageJson.version}\n`;
   const divider = '-----------\n';
 
   const startIndexOfRepoLine = fileContents.indexOf(repoLine);
@@ -64,9 +64,7 @@ function getNoticesWithoutRepoLicense(fileContents) {
   } else {
     // remove repo's package name
     let repoLicenseSection = fileContents.slice(startIndexOfRepoLicense, endIndexOfRepoLicense);
-    const startIndexOfrepoLineInSection = repoLicenseSection.indexOf(repoLine);
-    const endIndexOfRepoLineInSection = repoLicenseSection.indexOf('\n', startIndexOfrepoLineInSection) + 1;
-    repoLicenseSection = repoLicenseSection.slice(0, startIndexOfrepoLineInSection) + repoLicenseSection.slice(endIndexOfRepoLineInSection);
+    repoLicenseSection = repoLicenseSection.replace(repoLine, '');
 
     if (numPackagesWithSharedLicense === 2) {
       repoLicenseSection = repoLicenseSection.replace(

--- a/scripts/remove-repo-license.js
+++ b/scripts/remove-repo-license.js
@@ -47,35 +47,39 @@ function getNoticesWithoutRepoLicense(fileContents) {
   const repoLine = ` - ${packageJson.name}`;
   const divider = '-----------\n';
 
-  const indexOfRepoLine = fileContents.indexOf(repoLine);
-  if (indexOfRepoLine === -1) {
+  const startIndexOfRepoLine = fileContents.indexOf(repoLine);
+  if (startIndexOfRepoLine === -1) {
     return fileContents;
   }
 
   // determine how many packages share the same license as current repo
-  const startIndexOfRepoDivider = fileContents.lastIndexOf(divider, indexOfRepoLine);
+  const startIndexOfRepoDivider = fileContents.lastIndexOf(divider, startIndexOfRepoLine);
   const startIndexOfRepoLicense = startIndexOfRepoDivider === -1 ? 0 : startIndexOfRepoDivider + divider.length;
+  const endIndexOfRepoLicense = fileContents.indexOf(divider, startIndexOfRepoLicense) + divider.length;
   const numPackagesWithSharedLicense = countNumPackagesWithSharedLicense(fileContents, startIndexOfRepoLicense);
 
   if (numPackagesWithSharedLicense === 1) {
     // remove repo's license
-    const endIndexOfRepoLicense = fileContents.indexOf(divider, startIndexOfRepoLicense) + divider.length;
     return fileContents.slice(0, startIndexOfRepoLicense) + fileContents.slice(endIndexOfRepoLicense);
   } else {
     // remove repo's package name
-    const endIndexOfRepoLine = fileContents.indexOf('\n', indexOfRepoLine) + 1;
-    let modifiedFileContents = fileContents.slice(0, indexOfRepoLine) + fileContents.slice(endIndexOfRepoLine);
+    let repoLicenseSection = fileContents.slice(startIndexOfRepoLicense, endIndexOfRepoLicense);
+    const startIndexOfrepoLineInSection = repoLicenseSection.indexOf(repoLine);
+    const endIndexOfRepoLineInSection = repoLicenseSection.indexOf('\n', startIndexOfrepoLineInSection) + 1;
+    repoLicenseSection = repoLicenseSection.slice(0, startIndexOfrepoLineInSection) + repoLicenseSection.slice(endIndexOfRepoLineInSection);
 
     if (numPackagesWithSharedLicense === 2) {
-      modifiedFileContents = modifiedFileContents.replace(
+      repoLicenseSection = repoLicenseSection.replace(
         'The following NPM packages may be included in this product:', 
         'The following NPM package may be included in this product:');
-      modifiedFileContents = modifiedFileContents.replace(
+        repoLicenseSection = repoLicenseSection.replace(
         'These packages each contain the following license and notice below:', 
         'This package contains the following license and notice below:'
       );
     }
-    return modifiedFileContents;
+    const contentsBeforeRepoLicense = fileContents.slice(0, startIndexOfRepoLicense)
+    const contentsAfterRepoLicense = fileContents.slice(endIndexOfRepoLicense);
+    return contentsBeforeRepoLicense + repoLicenseSection + contentsAfterRepoLicense;
   }
 }
 

--- a/scripts/remove-repo-license.js
+++ b/scripts/remove-repo-license.js
@@ -9,40 +9,74 @@ function removeRepoLicense() {
   const noticesFile = './THIRD-PARTY-NOTICES';
 
   const noticesFileContents = fs.readFileSync(noticesFile, 'utf8');
-  const noticesWithoutRepoLicense = getNoticesWithoutReactSiteStarterLicense(noticesFileContents);
+  const noticesWithoutRepoLicense = getNoticesWithoutRepoLicense(noticesFileContents);
 
   fs.writeFileSync(noticesFile, noticesWithoutRepoLicense);
 }
 
 /**
- * Removes the repo's library license from the 3rd party notices file
- * contents and returns the updated file as a string
+ * Return number of packages that share the same license as the current repo 
+ * in the third party notices file
+ * @param {string} fileContents The contents of the 3rd party notices file
+ * @param {number} licenseStart the index at the start of the repo's license section
+ */
+function countNumPackagesWithSharedLicense(fileContents, licenseStart) {
+  const packageNameRegex = / - .*@.*/;
+  let atPackageName = true;
+  let currentFileIndex = licenseStart + packageNameRegex.exec(fileContents.slice(licenseStart)).index;
+  let numPackagesWithSharedLicense = 0;
+  while (atPackageName) {
+    const line = fileContents.slice(currentFileIndex, fileContents.indexOf('\n', currentFileIndex));
+    atPackageName = packageNameRegex.test(line);
+    if (atPackageName) {
+      numPackagesWithSharedLicense++;
+    }
+    currentFileIndex += line.length + 1;
+  }
+  return numPackagesWithSharedLicense;
+}
+
+/**
+ * Removes the repo's package name and/or library license from the 3rd party
+ * notices file contents and returns the updated file as a string
  *
  * @param {string} fileContents The contents of the 3rd party notices file
  * @returns {string}
  */
-function getNoticesWithoutReactSiteStarterLicense(fileContents) {
-  const packageName = packageJson.name;
-  const repoLine = ` - ${packageName}`;
-  const licenseStart = 'The following NPM package may be included in this product:';
-  const divider = '-----------';
-  const numNewLinesAfterDivider = 2;
+function getNoticesWithoutRepoLicense(fileContents) {
+  const repoLine = ` - ${packageJson.name}`;
+  const divider = '-----------\n';
 
   const indexOfRepoLine = fileContents.indexOf(repoLine);
   if (indexOfRepoLine === -1) {
     return fileContents;
   }
 
-  const startOfRepoLicense = fileContents.lastIndexOf(licenseStart, indexOfRepoLine);
-  const endOfRepoLicense =
-    fileContents.indexOf(divider, startOfRepoLicense)
-    + divider.length
-    + numNewLinesAfterDivider;
+  // determine how many packages share the same license as current repo
+  const startIndexOfRepoDivider = fileContents.lastIndexOf(divider, indexOfRepoLine);
+  const startIndexOfRepoLicense = startIndexOfRepoDivider === -1 ? 0 : startIndexOfRepoDivider + divider.length;
+  const numPackagesWithSharedLicense = countNumPackagesWithSharedLicense(fileContents, startIndexOfRepoLicense);
 
-  const fileBeforeRepoLicense = fileContents.slice(0, startOfRepoLicense);
-  const fileAfterRepoLicense = fileContents.slice(endOfRepoLicense);
+  if (numPackagesWithSharedLicense === 1) {
+    // remove repo's license
+    const endIndexOfRepoLicense = fileContents.indexOf(divider, startIndexOfRepoLicense) + divider.length;
+    return fileContents.slice(0, startIndexOfRepoLicense) + fileContents.slice(endIndexOfRepoLicense);
+  } else {
+    // remove repo's package name
+    const endIndexOfRepoLine = fileContents.indexOf('\n', indexOfRepoLine) + 1;
+    let modifiedFileContents = fileContents.slice(0, indexOfRepoLine) + fileContents.slice(endIndexOfRepoLine);
 
-  return fileBeforeRepoLicense + fileAfterRepoLicense;
+    if (numPackagesWithSharedLicense === 2) {
+      modifiedFileContents = modifiedFileContents.replace(
+        'The following NPM packages may be included in this product:', 
+        'The following NPM package may be included in this product:');
+      modifiedFileContents = modifiedFileContents.replace(
+        'These packages each contain the following license and notice below:', 
+        'This package contains the following license and notice below:'
+      );
+    }
+    return modifiedFileContents;
+  }
 }
 
 removeRepoLicense();

--- a/scripts/remove-repo-license.js
+++ b/scripts/remove-repo-license.js
@@ -19,11 +19,12 @@ function removeRepoLicense() {
  * in the third party notices file
  * @param {string} fileContents The contents of the 3rd party notices file
  * @param {number} licenseStart the index at the start of the repo's license section
+ * @returns {string}
  */
 function countNumPackagesWithSharedLicense(fileContents, licenseStart) {
   const packageNameRegex = / - .*@.*/;
-  let atPackageName = true;
   let currentFileIndex = licenseStart + packageNameRegex.exec(fileContents.slice(licenseStart)).index;
+  let atPackageName = true;
   let numPackagesWithSharedLicense = 0;
   while (atPackageName) {
     const line = fileContents.slice(currentFileIndex, fileContents.indexOf('\n', currentFileIndex));
@@ -70,10 +71,9 @@ function getNoticesWithoutRepoLicense(fileContents) {
       repoLicenseSection = repoLicenseSection.replace(
         'The following NPM packages may be included in this product:', 
         'The following NPM package may be included in this product:');
-        repoLicenseSection = repoLicenseSection.replace(
+      repoLicenseSection = repoLicenseSection.replace(
         'These packages each contain the following license and notice below:', 
-        'This package contains the following license and notice below:'
-      );
+        'This package contains the following license and notice below:');
     }
     const contentsBeforeRepoLicense = fileContents.slice(0, startIndexOfRepoLicense)
     const contentsAfterRepoLicense = fileContents.slice(endIndexOfRepoLicense);


### PR DESCRIPTION
update script to consider three cases when removing current repo from third party notices file:
  1) current repo have its own license section => remove the entire section
  2) current repo share license section with another package => remove repo name and update grammar
  3) current repo share license section with 2(+) other packages => remove repo name

J=SLAP-1754
TEST=manual

run scripts based on the three scenarios above and see that it works accordingly