### PR TITLE
Update searchThroughFacet

### DIFF
--- a/src/answers-utilities.ts
+++ b/src/answers-utilities.ts
@@ -4,7 +4,7 @@ import { isLevenshteinMatch } from './utils/searchable-facets';
 export default {
   /**
    * Searches through the specified facet and filters out the options that aren't a
-   * close match for the given searchTerm.
+   * close match for the given searchTerm. The comparison is case insensitive.
    *
    * @param facet - The facet whose options are searched through
    * @param searchTerm - The search term to compare the facet options against
@@ -14,7 +14,9 @@ export default {
   searchThroughFacet(facet: DisplayableFacet, searchTerm: string): DisplayableFacet {
     return {
       ...facet,
-      options: facet.options.filter(o => isLevenshteinMatch(o.displayName, searchTerm))
+      options: facet.options.filter(o =>
+        isLevenshteinMatch(o.displayName.toLowerCase(), searchTerm.toLowerCase())
+      )
     };
   }
 };

--- a/tests/integration/facets.ts
+++ b/tests/integration/facets.ts
@@ -196,6 +196,80 @@ it('searchThroughFacet filters facet options correctly', () => {
   });
 });
 
+it('searchThroughFacet filters facet options correctly for similar searchTerm', () => {
+  const [initialState, facetOption] = createInitialState(false);
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'generation'
+  });
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'cation'
+  });
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'Cation'
+  });
+  const answers = createMockedAnswersHeadless({}, initialState);
+  const facet = answers.state.filters.facets[0];
+  const searchedFacet = answers.utilities.searchThroughFacet(facet, 'car');
+  expect(searchedFacet).toEqual({
+    displayName: 'test facet name',
+    fieldId: 'testFieldId',
+    options: [
+      {
+        ...facetOption,
+        displayName: 'cation'
+      },
+      {
+        ...facetOption,
+        displayName: 'Cation'
+      }
+    ]
+  });
+});
+
+it('searchThroughFacet filters facet options correctly for short searchTerm', () => {
+  const [initialState, facetOption] = createInitialState(false);
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'macaw'
+  });
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'cation'
+  });
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'Caution'
+  });
+  initialState.filters.facets[0].options.push({
+    ...facetOption,
+    displayName: 'ignore me'
+  });
+  const answers = createMockedAnswersHeadless({}, initialState);
+  const facet = answers.state.filters.facets[0];
+  const searchedFacet = answers.utilities.searchThroughFacet(facet, 'ca');
+  expect(searchedFacet).toEqual({
+    displayName: 'test facet name',
+    fieldId: 'testFieldId',
+    options: [
+      {
+        ...facetOption,
+        displayName: 'macaw'
+      },
+      {
+        ...facetOption,
+        displayName: 'cation'
+      },
+      {
+        ...facetOption,
+        displayName: 'Caution'
+      }
+    ]
+  });
+});
+
 it('can set facets correctly', () => {
   const [initialState, facetOption] = createInitialState(true);
   const answers = createMockedAnswersHeadless({}, initialState);


### PR DESCRIPTION
Changes `searchThroughFacet` to be case insensitive (for both substring matching and Levenshtein matching).

J=SLAP-1782
TEST=auto, manual

Added additional tests to verify case-insensitivity and that search terms with length less than 3 characters return correct facet options without using Levenshtein. See this behavior reflected in the sample app.