### PR TITLE
track src folder in npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "1.1.0-beta.2",
+      "version": "1.1.0-beta.3",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json && npm run api-extractor && npm run generate-docs",


### PR DESCRIPTION
This is needed for source maps to work as expected.
see https://github.com/yext/answers-core/pull/129

J=SLAP-1798
TEST=manual

create-react-app v5 source map generation works with answers-headless