### PR TITLE
Update setVertical and setUniversal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.3",
+  "version": "1.1.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "1.1.0-beta.3",
+      "version": "1.1.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.3",
+  "version": "1.1.0-beta.4",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -27,6 +27,12 @@ import * as answersUtilities from './answers-utilities';
 import { SelectableFilter } from './models/utils/selectablefilter';
 import { transformFiltersToCoreFormat } from './utils/transform-filters';
 import { SearchTypeEnum } from './models/utils/searchType';
+import { initialState as initialVerticalState } from './slices/vertical';
+import { initialState as initialUniversalState } from './slices/universal';
+import { initialState as initialFiltersState } from './slices/filters';
+import { initialState as initialDirectAnswerState } from './slices/directanswer';
+import { initialState as initialQueryRulesState } from './slices/queryrules';
+import { initialState as initialSearchStatusState } from './slices/searchstatus';
 
 /**
  * Provides the functionality for interacting with an Answers Search experience.
@@ -81,12 +87,7 @@ export default class AnswersHeadless {
    * @param verticalKey - The vertical key to set
    */
   setVertical(verticalKey: string): void {
-    this.setState({
-      ...this.state,
-      filters: {},
-      vertical: {},
-      universal: {}
-    });
+    this._resetSearcherStates();
     this.stateManager.dispatchEvent('vertical/setVerticalKey', verticalKey);
     this.stateManager.dispatchEvent('meta/setSearchType', SearchTypeEnum.Vertical);
   }
@@ -95,14 +96,25 @@ export default class AnswersHeadless {
    * Sets up Headless to manage universal searches.
    */
   setUniversal(): void {
-    this.setState({
-      ...this.state,
-      filters: {},
-      vertical: {},
-      universal: {}
-    });
+    this._resetSearcherStates();
     this.stateManager.dispatchEvent('vertical/setVerticalKey', undefined);
     this.stateManager.dispatchEvent('meta/setSearchType', SearchTypeEnum.Universal);
+  }
+
+  /**
+   * Resets the direct answer, filters, query rules, search status, vertical, and universal states
+   * to their initial values.
+   */
+  private _resetSearcherStates() {
+    this.stateManager.dispatchEvent('set-state', {
+      ...this.state,
+      directAnswer: initialDirectAnswerState,
+      filters: initialFiltersState,
+      queryRules: initialQueryRulesState,
+      searchStatus: initialSearchStatusState,
+      vertical: initialVerticalState,
+      universal: initialUniversalState
+    });
   }
 
   /**

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -81,6 +81,12 @@ export default class AnswersHeadless {
    * @param verticalKey - The vertical key to set
    */
   setVertical(verticalKey: string): void {
+    this.setState({
+      ...this.state,
+      filters: {},
+      vertical: {},
+      universal: {}
+    });
     this.stateManager.dispatchEvent('vertical/setVerticalKey', verticalKey);
     this.stateManager.dispatchEvent('meta/setSearchType', SearchTypeEnum.Vertical);
   }
@@ -89,6 +95,12 @@ export default class AnswersHeadless {
    * Sets up Headless to manage universal searches.
    */
   setUniversal(): void {
+    this.setState({
+      ...this.state,
+      filters: {},
+      vertical: {},
+      universal: {}
+    });
     this.stateManager.dispatchEvent('vertical/setVerticalKey', undefined);
     this.stateManager.dispatchEvent('meta/setSearchType', SearchTypeEnum.Universal);
   }

--- a/src/slices/directanswer.ts
+++ b/src/slices/directanswer.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { FeaturedSnippetDirectAnswer, FieldValueDirectAnswer } from '@yext/answers-core';
 import { DirectAnswerState } from '../models/slices/directanswer';
 
-const initialState: DirectAnswerState = {};
+export const initialState: DirectAnswerState = {};
 
 const reducers = {
   setResult: (

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -4,7 +4,7 @@ import { FiltersState } from '../models/slices/filters';
 import { SelectableFilter } from '../models/utils/selectablefilter';
 import { areFiltersEqual } from '../utils/filter-utils';
 
-const initialState: FiltersState = {};
+export const initialState: FiltersState = {};
 
 interface FacetPayload {
   fieldId: string

--- a/src/slices/queryrules.ts
+++ b/src/slices/queryrules.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { QueryRulesActionsData } from '@yext/answers-core';
 import { QueryRulesState } from '../models/slices/queryrules';
 
-const initialState: QueryRulesState = { actions: [] };
+export const initialState: QueryRulesState = { actions: [] };
 
 const reducers = {
   setActions: (state, action: PayloadAction<QueryRulesActionsData[]>) => {

--- a/src/slices/searchstatus.ts
+++ b/src/slices/searchstatus.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { SearchStatusState } from '../models/slices/searchstatus';
 
-const initialState: SearchStatusState = {};
+export const initialState: SearchStatusState = {};
 
 const reducers = {
   setIsLoading: (state, action: PayloadAction<boolean>) => {

--- a/src/slices/universal.ts
+++ b/src/slices/universal.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { UniversalLimit, VerticalResults } from '@yext/answers-core';
 import { UniversalSearchState } from '../models/slices/universal';
 
-const initialState: UniversalSearchState = {};
+export const initialState: UniversalSearchState = {};
 
 const reducers = {
   setVerticals: (state: UniversalSearchState, action: PayloadAction<VerticalResults[]>) => {

--- a/src/slices/vertical.ts
+++ b/src/slices/vertical.ts
@@ -5,7 +5,7 @@ import {
 } from '@yext/answers-core';
 import { AllResultsForVertical, VerticalSearchState } from '../models/slices/vertical';
 
-const initialState: VerticalSearchState = {};
+export const initialState: VerticalSearchState = {};
 
 const reducers = {
   handleSearchResponse: (

--- a/tests/integration/facets.ts
+++ b/tests/integration/facets.ts
@@ -146,6 +146,7 @@ it('only selected facets are sent in the vertical search request', () => {
   };
   const answers = createMockedAnswersHeadless(mockedCore, initialState);
   answers.setVertical('vertical-key');
+  answers.setFacets(initialState.filters.facets);
   answers.executeVerticalQuery();
   expect(mockedCore.verticalSearch).toHaveBeenCalledWith(expect.objectContaining({
     facets: [{

--- a/tests/integration/query.ts
+++ b/tests/integration/query.ts
@@ -96,7 +96,7 @@ describe('ensure correct results from latest request', () => {
   it('vertical search get correct results based on up-to-date response', async () => {
     const answers = getAnswersHeadless(requestsTime);
     answers.setVertical('someKey');
-    const removeListener = answers.addListener({
+    answers.addListener({
       valueAccessor: state => state.vertical?.results,
       callback: updateResult
     });
@@ -118,13 +118,12 @@ describe('ensure correct results from latest request', () => {
     expect(answers.state.query.input).toEqual(queries[2]);
     expect(answers.state.vertical.results).toEqual([queries[2]]);
     expect(updateResult.mock.calls).toHaveLength(2);
-    removeListener();
   });
 
   it('universal search get correct results based on up-to-date response', async () => {
     const answers = getAnswersHeadless(requestsTime);
     answers.setUniversal();
-    const removeListener = answers.addListener({
+    answers.addListener({
       valueAccessor: state => state.universal.verticals,
       callback: updateResult
     });
@@ -146,7 +145,6 @@ describe('ensure correct results from latest request', () => {
     expect(answers.state.query.input).toEqual(queries[2]);
     expect(answers.state.universal.verticals).toEqual([{ results: [queries[2]] }]);
     expect(updateResult.mock.calls).toHaveLength(2);
-    removeListener();
   });
 });
 

--- a/tests/integration/query.ts
+++ b/tests/integration/query.ts
@@ -112,7 +112,7 @@ describe('ensure correct results from latest request', () => {
   });
 
   it('vertical search get correct results based on up-to-date response', async () => {
-    answers.addListener({
+    const removeListener = answers.addListener({
       valueAccessor: state => state.vertical?.results,
       callback: updateResult
     });
@@ -134,11 +134,12 @@ describe('ensure correct results from latest request', () => {
     expect(answers.state.query.input).toEqual(queries[2]);
     expect(answers.state.vertical.results).toEqual([queries[2]]);
     expect(updateResult.mock.calls).toHaveLength(2);
+    removeListener();
   });
 
   it('universal search get correct results based on up-to-date response', async () => {
     answers.setUniversal();
-    answers.addListener({
+    const removeListener = answers.addListener({
       valueAccessor: state => state.universal.verticals,
       callback: updateResult
     });
@@ -160,5 +161,6 @@ describe('ensure correct results from latest request', () => {
     expect(answers.state.query.input).toEqual(queries[2]);
     expect(answers.state.universal.verticals).toEqual([{ results: [queries[2]] }]);
     expect(updateResult.mock.calls).toHaveLength(2);
+    removeListener();
   });
 });

--- a/tests/integration/query.ts
+++ b/tests/integration/query.ts
@@ -87,24 +87,6 @@ describe('ensure correct results from latest request', () => {
     [queries[1]]: 5,
     [queries[2]]: 12
   };
-
-  const mockedCore: any = {
-    verticalSearch: jest.fn( async (request: VerticalSearchRequest) => {
-      const waitTime = requestsTime[request.query];
-      return new Promise(res => setTimeout(() => res(
-        { verticalResults: { results: [request.query] } }), waitTime));
-    }),
-    universalSearch: jest.fn( async (request: UniversalSearchRequest) => {
-      const waitTime = requestsTime[request.query];
-      return new Promise(res => setTimeout(() => res(
-        { verticalResults: [{ results: [request.query] }] }), waitTime));
-    })
-  };
-  const stateManager = new ReduxStateManager(
-    createBaseStore(), DEFAULT_HEADLESS_ID, new HeadlessReducerManager());
-  const httpManager = new HttpManager();
-  const answers = new AnswersHeadless(mockedCore, stateManager, httpManager);
-  answers.setVertical('someKey');
   const updateResult = jest.fn();
 
   beforeEach(() => {
@@ -112,6 +94,8 @@ describe('ensure correct results from latest request', () => {
   });
 
   it('vertical search get correct results based on up-to-date response', async () => {
+    const answers = getAnswersHeadless(requestsTime);
+    answers.setVertical('someKey');
     const removeListener = answers.addListener({
       valueAccessor: state => state.vertical?.results,
       callback: updateResult
@@ -138,6 +122,7 @@ describe('ensure correct results from latest request', () => {
   });
 
   it('universal search get correct results based on up-to-date response', async () => {
+    const answers = getAnswersHeadless(requestsTime);
     answers.setUniversal();
     const removeListener = answers.addListener({
       valueAccessor: state => state.universal.verticals,
@@ -164,3 +149,22 @@ describe('ensure correct results from latest request', () => {
     removeListener();
   });
 });
+
+function getAnswersHeadless(requestsTime: { [x: string]: number }) {
+  const mockedCore: any = {
+    verticalSearch: jest.fn( async (request: VerticalSearchRequest) => {
+      const waitTime = requestsTime[request.query];
+      return new Promise(res => setTimeout(() => res(
+        { verticalResults: { results: [request.query] } }), waitTime));
+    }),
+    universalSearch: jest.fn( async (request: UniversalSearchRequest) => {
+      const waitTime = requestsTime[request.query];
+      return new Promise(res => setTimeout(() => res(
+        { verticalResults: [{ results: [request.query] }] }), waitTime));
+    })
+  };
+  const stateManager = new ReduxStateManager(
+    createBaseStore(), DEFAULT_HEADLESS_ID, new HeadlessReducerManager());
+  const httpManager = new HttpManager();
+  return new AnswersHeadless(mockedCore, stateManager, httpManager);
+}

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -180,11 +180,18 @@ describe('setters work as expected', () => {
     const dispatchEventCalls =
       mockedStateManager.dispatchEvent.mock.calls;
 
-    expect(dispatchEventCalls.length).toBe(2);
-    expect(dispatchEventCalls[0][0]).toBe('vertical/setVerticalKey');
-    expect(dispatchEventCalls[0][1]).toBe(verticalKey);
-    expect(dispatchEventCalls[1][0]).toBe('meta/setSearchType');
-    expect(dispatchEventCalls[1][1]).toBe(SearchTypeEnum.Vertical);
+    expect(dispatchEventCalls.length).toBe(3);
+    expect(dispatchEventCalls[0][0]).toBe('set-state');
+    expect(dispatchEventCalls[0][1]).toStrictEqual({
+      ...answers.state,
+      filters: {},
+      vertical: {},
+      universal: {}
+    });
+    expect(dispatchEventCalls[1][0]).toBe('vertical/setVerticalKey');
+    expect(dispatchEventCalls[1][1]).toBe(verticalKey);
+    expect(dispatchEventCalls[2][0]).toBe('meta/setSearchType');
+    expect(dispatchEventCalls[2][1]).toBe(SearchTypeEnum.Vertical);
   });
 
   it('setUniversal works as expected', () => {
@@ -193,11 +200,18 @@ describe('setters work as expected', () => {
     const dispatchEventCalls =
       mockedStateManager.dispatchEvent.mock.calls;
 
-    expect(dispatchEventCalls.length).toBe(2);
-    expect(dispatchEventCalls[0][0]).toBe('vertical/setVerticalKey');
-    expect(dispatchEventCalls[0][1]).toBe(undefined);
-    expect(dispatchEventCalls[1][0]).toBe('meta/setSearchType');
-    expect(dispatchEventCalls[1][1]).toBe(SearchTypeEnum.Universal);
+    expect(dispatchEventCalls.length).toBe(3);
+    expect(dispatchEventCalls[0][0]).toBe('set-state');
+    expect(dispatchEventCalls[0][1]).toStrictEqual({
+      ...answers.state,
+      filters: {},
+      vertical: {},
+      universal: {}
+    });
+    expect(dispatchEventCalls[1][0]).toBe('vertical/setVerticalKey');
+    expect(dispatchEventCalls[1][1]).toBe(undefined);
+    expect(dispatchEventCalls[2][0]).toBe('meta/setSearchType');
+    expect(dispatchEventCalls[2][1]).toBe(SearchTypeEnum.Universal);
   });
 
   it('setState works as expected', () => {

--- a/tests/unit/answers-headless.ts
+++ b/tests/unit/answers-headless.ts
@@ -5,6 +5,12 @@ import AnswersHeadless from '../../src/answers-headless';
 import { SelectableFilter } from '../../src/models/utils/selectablefilter';
 import { State } from '../../src/models/state';
 import { SearchTypeEnum } from '../../src/models/utils/searchType';
+import { initialState as initialVerticalState } from '../../src/slices/vertical';
+import { initialState as initialUniversalState } from '../../src/slices/universal';
+import { initialState as initialFiltersState } from '../../src/slices/filters';
+import { initialState as initialDirectAnswerState } from '../../src/slices/directanswer';
+import { initialState as initialQueryRulesState } from '../../src/slices/queryrules';
+import { initialState as initialSearchStatusState } from '../../src/slices/searchstatus';
 
 const mockedState: State = {
   query: {
@@ -184,9 +190,12 @@ describe('setters work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('set-state');
     expect(dispatchEventCalls[0][1]).toStrictEqual({
       ...answers.state,
-      filters: {},
-      vertical: {},
-      universal: {}
+      directAnswer: initialDirectAnswerState,
+      filters: initialFiltersState,
+      queryRules: initialQueryRulesState,
+      searchStatus: initialSearchStatusState,
+      vertical: initialVerticalState,
+      universal: initialUniversalState
     });
     expect(dispatchEventCalls[1][0]).toBe('vertical/setVerticalKey');
     expect(dispatchEventCalls[1][1]).toBe(verticalKey);
@@ -204,9 +213,12 @@ describe('setters work as expected', () => {
     expect(dispatchEventCalls[0][0]).toBe('set-state');
     expect(dispatchEventCalls[0][1]).toStrictEqual({
       ...answers.state,
-      filters: {},
-      vertical: {},
-      universal: {}
+      directAnswer: initialDirectAnswerState,
+      filters: initialFiltersState,
+      queryRules: initialQueryRulesState,
+      searchStatus: initialSearchStatusState,
+      vertical: initialVerticalState,
+      universal: initialUniversalState
     });
     expect(dispatchEventCalls[1][0]).toBe('vertical/setVerticalKey');
     expect(dispatchEventCalls[1][1]).toBe(undefined);


### PR DESCRIPTION
Reset the existing filters, results, direct answer, query rules custom data, and search status to their initial states when switching to a new searcher using `setUniversal` or `setVertical` because these states pertain only to the previous searcher.

J=SLAP-1910
TEST=auto

Check that the updated jest tests pass.