### PR TITLE
handle core rejected promise in universal/vertical search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "1.1.0-beta.7",
+      "version": "1.1.0-beta.8",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -330,7 +330,7 @@ export default class AnswersHeadless {
       if (isLatestResponse) {
         this.stateManager.dispatchEvent('searchStatus/setIsLoading', false);
       }
-      throw e;
+      return Promise.reject(e);
     }
     const isLatestResponse = this.httpManager.processRequestId('universalQuery', thisRequestId);
     if (!isLatestResponse) {

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -308,7 +308,7 @@ export default class AnswersHeadless {
     const { referrerPageUrl, context } = this.state.meta;
     const { userLocation } = this.state.location;
 
-    const response = await this.core.universalSearch({
+    const request = {
       query: input || '',
       querySource,
       queryTrigger,
@@ -320,7 +320,19 @@ export default class AnswersHeadless {
       context,
       referrerPageUrl,
       restrictVerticals
-    });
+    };
+
+    let response = undefined;
+    try {
+      response = await this.core.universalSearch(request);
+    } catch (e) {
+      const latestResponseId = this.httpManager.getLatestResponseId('universalQuery');
+      if (thisRequestId > latestResponseId) {
+        this.stateManager.dispatchEvent('searchStatus/setIsLoading', false);
+        this.httpManager.setResponseId('universalQuery', thisRequestId);
+      }
+      return Promise.reject(e);
+    }
 
     const latestResponseId = this.httpManager.getLatestResponseId('universalQuery');
     if (thisRequestId < latestResponseId) {
@@ -410,7 +422,19 @@ export default class AnswersHeadless {
       context,
       referrerPageUrl
     };
-    const response = await this.core.verticalSearch(request);
+
+    let response = undefined;
+    try {
+      response = await this.core.verticalSearch(request);
+    } catch (e) {
+      const latestResponseId = this.httpManager.getLatestResponseId('verticalQuery');
+      if (thisRequestId > latestResponseId) {
+        this.stateManager.dispatchEvent('searchStatus/setIsLoading', false);
+        this.httpManager.setResponseId('verticalQuery', thisRequestId);
+      }
+      return Promise.reject(e);
+    }
+
     const latestResponseId = this.httpManager.getLatestResponseId('verticalQuery');
     if (thisRequestId < latestResponseId) {
       return response;

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -322,7 +322,7 @@ export default class AnswersHeadless {
       restrictVerticals
     };
 
-    let response = undefined;
+    let response: UniversalSearchResponse;
     try {
       response = await this.core.universalSearch(request);
     } catch (e) {
@@ -423,7 +423,7 @@ export default class AnswersHeadless {
       referrerPageUrl
     };
 
-    let response = undefined;
+    let response: VerticalSearchResponse;
     try {
       response = await this.core.verticalSearch(request);
     } catch (e) {

--- a/src/answers-headless.ts
+++ b/src/answers-headless.ts
@@ -326,19 +326,16 @@ export default class AnswersHeadless {
     try {
       response = await this.core.universalSearch(request);
     } catch (e) {
-      const latestResponseId = this.httpManager.getLatestResponseId('universalQuery');
-      if (thisRequestId > latestResponseId) {
+      const isLatestResponse = this.httpManager.processRequestId('universalQuery', thisRequestId);
+      if (isLatestResponse) {
         this.stateManager.dispatchEvent('searchStatus/setIsLoading', false);
-        this.httpManager.setResponseId('universalQuery', thisRequestId);
       }
-      return Promise.reject(e);
+      throw e;
     }
-
-    const latestResponseId = this.httpManager.getLatestResponseId('universalQuery');
-    if (thisRequestId < latestResponseId) {
+    const isLatestResponse = this.httpManager.processRequestId('universalQuery', thisRequestId);
+    if (!isLatestResponse) {
       return response;
     }
-    this.httpManager.setResponseId('universalQuery', thisRequestId);
     this.stateManager.dispatchEvent('universal/setVerticals', response.verticalResults);
     this.stateManager.dispatchEvent('query/setQueryId', response.queryId);
     this.stateManager.dispatchEvent('query/setMostRecentSearch', input);
@@ -427,19 +424,17 @@ export default class AnswersHeadless {
     try {
       response = await this.core.verticalSearch(request);
     } catch (e) {
-      const latestResponseId = this.httpManager.getLatestResponseId('verticalQuery');
-      if (thisRequestId > latestResponseId) {
+      const isLatestResponse = this.httpManager.processRequestId('verticalQuery', thisRequestId);
+      if (isLatestResponse) {
         this.stateManager.dispatchEvent('searchStatus/setIsLoading', false);
-        this.httpManager.setResponseId('verticalQuery', thisRequestId);
       }
       return Promise.reject(e);
     }
 
-    const latestResponseId = this.httpManager.getLatestResponseId('verticalQuery');
-    if (thisRequestId < latestResponseId) {
+    const isLatestResponse = this.httpManager.processRequestId('verticalQuery', thisRequestId);
+    if (!isLatestResponse) {
       return response;
     }
-    this.httpManager.setResponseId('verticalQuery', thisRequestId);
     this.stateManager.dispatchEvent('query/setQueryId', response.queryId);
     this.stateManager.dispatchEvent('query/setMostRecentSearch', input);
     this.stateManager.dispatchEvent('filters/setFacets', response.facets);

--- a/src/http-manager.ts
+++ b/src/http-manager.ts
@@ -40,8 +40,8 @@ export default class HttpManager {
   }
 
   /**
-   * Update the recorded received response id of the given service type if
-   * the given request id corresponds to the latest response.
+   * Update the latest saved response id of the given service type if
+   * the given request id is newer than the latest saved response id.
    *
    * @param requestName - the request type.
    * @param requestId - the request id of a received response.

--- a/src/http-manager.ts
+++ b/src/http-manager.ts
@@ -38,4 +38,22 @@ export default class HttpManager {
   getLatestResponseId(responseName: ServiceType): number {
     return this.latestResponseIds[responseName];
   }
+
+  /**
+   * Update the recorded received response id of the given service type if
+   * the given request id corresponds to the latest response.
+   *
+   * @param requestName - the request type.
+   * @param requestId - the request id of a received response.
+   *
+   * @returns Whether the response of the given request id is the latest response.
+   */
+  processRequestId(requestName: ServiceType, requestId: number): boolean {
+    const latestResponseId = this.getLatestResponseId(requestName);
+    if (requestId > latestResponseId) {
+      this.setResponseId(requestName, requestId);
+      return true;
+    }
+    return false;
+  }
 }

--- a/tests/integration/universalsearch.ts
+++ b/tests/integration/universalsearch.ts
@@ -1,4 +1,5 @@
 import { UniversalSearchRequest } from '@yext/answers-core';
+import HttpManager from '../../src/http-manager';
 import { createMockedAnswersHeadless } from '../mocks/createMockedAnswersHeadless';
 import setTimeout from '../utils/setTimeout';
 
@@ -31,9 +32,30 @@ it('answers.setRestrictVerticals sets the restrictVerticals param', async () => 
   expect(mockSearch.mock.calls[0][0].restrictVerticals).toEqual(['KM', 'people']);
 });
 
+it('handle a rejected promise from core', async () => {
+  const mockSearch = createMockRejectedSearch();
+  const mockCore = { universalSearch: mockSearch };
+  const httpManager = new HttpManager();
+  const answers = createMockedAnswersHeadless(mockCore, {}, undefined, undefined, httpManager);
+  try {
+    await answers.executeUniversalQuery();
+  } catch (e) {
+    expect(e).toEqual('mock error message');
+  }
+  expect(answers.state.searchStatus.isLoading).toEqual(false);
+  expect(httpManager.getLatestResponseId('universalQuery')).toEqual(1);
+});
+
 function createMockSearch() {
   return jest.fn(async (_request: UniversalSearchRequest) => {
     await setTimeout(0);
     return Promise.resolve({});
+  });
+}
+
+function createMockRejectedSearch() {
+  return jest.fn(async (_request: UniversalSearchRequest) => {
+    await setTimeout(0);
+    return Promise.reject('mock error message');
   });
 }

--- a/tests/mocks/createMockedAnswersHeadless.ts
+++ b/tests/mocks/createMockedAnswersHeadless.ts
@@ -18,12 +18,13 @@ export function createMockedAnswersHeadless(
   mockedAnswersCore: any = {},
   initialState: Partial<State> = {},
   store?: EnhancedStore<ParentState, ActionWithHeadlessId>,
-  headlessReducerManager?: HeadlessReducerManager
+  headlessReducerManager?: HeadlessReducerManager,
+  httpManager?: HttpManager
 ): AnswersHeadless {
   const reduxStateManager = new ReduxStateManager(
     store || createBaseStore(), DEFAULT_HEADLESS_ID, headlessReducerManager || new HeadlessReducerManager());
-  const httpManager = new HttpManager();
-  const answers = new AnswersHeadless(mockedAnswersCore, reduxStateManager, httpManager);
+  const headlessHttpManager = httpManager || new HttpManager();
+  const answers = new AnswersHeadless(mockedAnswersCore, reduxStateManager, headlessHttpManager);
   answers.setState({
     ...answers.state,
     ...initialState


### PR DESCRIPTION
update `executeUniversalQuery` and `executeVerticalQuery` to handle rejected promise/error throw from core. Using try/catch, if there's a rejected promise from latest request, ensures isLoading state is set back to false and data in httpManager is up to date, before returning a rejected promise.

J=SLAP-1941
test=auto

see new jest tests fail without the changes. See all jest tests pass with changes from pr.