### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,18 +9,7 @@ on:
   pull_request:
 
 jobs:
-  Coveralls:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-    - run: npm ci
-    - run: npx jest --coverage
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+  call_code_coverage:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/coverage.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,19 +6,5 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build
-    - run: npm test
+  call_run_tests:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -3,19 +3,5 @@ name: Check Third Party Notices File
 on: pull_request
 
 jobs:
-  license-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-      - uses: actions/checkout@v2
-      - run: npm ci
-      - run: npm run generate-notices
-      - name: Update THIRD-PARTY-NOTICES
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: "Automated update to THIRD-PARTY-NOTICES from github action's 3rd party notices check"
-          add: 'THIRD-PARTY-NOTICES'
-          push: true
-          default_author: github_actions
+  call_notices_check:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/third_party_notices_check.yml@v1

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -3,25 +3,5 @@ name: Check and Update Repo's documenation
 on: pull_request
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [17.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build
-    - name: Update Documentation
-      uses: EndBug/add-and-commit@v7
-      with:
-        message: "Automated update to repo's documentation from github action"
-        add: '*.md'
-        push: true
-        default_author: github_actions
+  call_update_docs:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/update_docs.yml@v1


### PR DESCRIPTION
Update the github workflows to use the callable workflows in the `slapshot-reusable-workflows` repo.

J=SLAP-2005
TEST=auto

- See that all four workflows run on this PR as expected.
- Test on another branch (`dev/test-reusable-workflows`) and see that docs and third party notices are updated when needed.