### PR TITLE
redux changes to support react 18

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -32,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @reduxjs/toolkit@1.7.0
+ - @reduxjs/toolkit@1.8.1
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.12",
+  "version": "1.1.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "1.1.0-beta.12",
+      "version": "1.1.1-alpha.0",
       "license": "ISC",
       "dependencies": {
-        "@reduxjs/toolkit": "^1.7.0",
+        "@reduxjs/toolkit": "^1.8.1",
         "@yext/answers-core": "^1.6.0-beta.7",
         "js-levenshtein": "^1.1.6",
-        "lodash": "^4.17.21",
-        "redux-thunk": "^2.4.1"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.5",
@@ -2813,9 +2812,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0.tgz",
-      "integrity": "sha512-iApo4zS+8kWnIn4xucTDWpqRjDNkXruFIyJQWwThIEIbMj5kwqvbMaQcEgd2a305B68Z+4bvZqAqJSATeddaJA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
       "dependencies": {
         "immer": "^9.0.7",
         "redux": "^4.1.2",
@@ -2823,7 +2822,7 @@
         "reselect": "^4.1.5"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react": "^16.9.0 || ^17.0.0 || ^18",
         "react-redux": "^7.2.1 || ^8.0.0-beta"
       },
       "peerDependenciesMeta": {
@@ -13141,9 +13140,9 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.0.tgz",
-      "integrity": "sha512-iApo4zS+8kWnIn4xucTDWpqRjDNkXruFIyJQWwThIEIbMj5kwqvbMaQcEgd2a305B68Z+4bvZqAqJSATeddaJA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+      "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
       "requires": {
         "immer": "^9.0.7",
         "redux": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.1-alpha.0",
+  "version": "1.1.1-alpha.0-95",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/answers-headless",
-      "version": "1.1.1-alpha.0",
+      "version": "1.1.1-alpha.0-95",
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.0-beta.12",
+  "version": "1.1.1-alpha.0",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",
@@ -22,11 +22,10 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^1.7.0",
+    "@reduxjs/toolkit": "^1.8.1",
     "@yext/answers-core": "^1.6.0-beta.7",
     "js-levenshtein": "^1.1.6",
-    "lodash": "^4.17.21",
-    "redux-thunk": "^2.4.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/answers-headless",
-  "version": "1.1.1-alpha.0",
+  "version": "1.1.1-alpha.0-95",
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",

--- a/src/redux-state-manager.ts
+++ b/src/redux-state-manager.ts
@@ -1,9 +1,9 @@
-import { EnhancedStore, Unsubscribe } from '@reduxjs/toolkit';
+import { Unsubscribe } from '@reduxjs/toolkit';
 import StateListener from './models/state-listener';
 import StateManager from './models/state-manager';
-import { ParentState, State } from './models/state';
+import { State } from './models/state';
 import HeadlessReducerManager from './headless-reducer-manager';
-import { ActionWithHeadlessId } from './store';
+import { HeadlessEnhancedStore } from './store';
 
 /**
  * A Redux-backed implementation of the {@link StateManager} interface. Redux is used to
@@ -11,7 +11,7 @@ import { ActionWithHeadlessId } from './store';
  */
 export default class ReduxStateManager implements StateManager {
   constructor(
-    private store: EnhancedStore<ParentState, ActionWithHeadlessId>,
+    private store: HeadlessEnhancedStore,
     private headlessId: string,
     headlessReducerManager: HeadlessReducerManager
   ) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,21 +1,25 @@
-import { configureStore, EnhancedStore, Reducer, Middleware, PayloadAction } from '@reduxjs/toolkit';
+import { configureStore, EnhancedStore, Reducer, PayloadAction, AnyAction } from '@reduxjs/toolkit';
+import { ThunkMiddleware } from 'redux-thunk';
 import { ParentState } from './models/state';
 
 export interface ActionWithHeadlessId extends PayloadAction<unknown> {
   headlessId: string
 }
 
+export type HeadlessEnhancedStore =
+  EnhancedStore<ParentState, ActionWithHeadlessId, ThunkMiddleware<ParentState, AnyAction>[]>;
+
 /**
  * This reducer will be replaced by initializations of {@link ReduxStateManager}.
  * It is necessary to still have this reducer, though, otherwise Redux's `@@init`
  * event will not function properly.
  */
-const initialReducer: Reducer<ParentState> = (state: ParentState | undefined) => {
+const initialReducer: Reducer<ParentState, ActionWithHeadlessId> = (state: ParentState | undefined) => {
   return state || {};
 };
 
-export function createBaseStore(): EnhancedStore<ParentState, ActionWithHeadlessId> {
-  const store = configureStore<ParentState, ActionWithHeadlessId, Middleware<unknown, ParentState>[]>({
+export function createBaseStore(): HeadlessEnhancedStore {
+  const store = configureStore({
     middleware:
       (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false }),
     reducer: initialReducer,

--- a/tests/mocks/createMockedAnswersHeadless.ts
+++ b/tests/mocks/createMockedAnswersHeadless.ts
@@ -1,9 +1,8 @@
 import HttpManager from '../../src/http-manager';
-import { ParentState, State } from '../../src/models/state';
+import { State } from '../../src/models/state';
 import ReduxStateManager from '../../src/redux-state-manager';
 import AnswersHeadless from '../../src/answers-headless';
-import { ActionWithHeadlessId, createBaseStore } from '../../src/store';
-import { EnhancedStore } from '@reduxjs/toolkit';
+import { createBaseStore, HeadlessEnhancedStore } from '../../src/store';
 import { DEFAULT_HEADLESS_ID } from '../../src/constants';
 import HeadlessReducerManager from '../../src/headless-reducer-manager';
 import { getHttpHeaders } from '../../src/utils/client-sdk-utils';
@@ -18,7 +17,7 @@ import { getHttpHeaders } from '../../src/utils/client-sdk-utils';
 export function createMockedAnswersHeadless(
   mockedAnswersCore: any = {},
   initialState: Partial<State> = {},
-  store?: EnhancedStore<ParentState, ActionWithHeadlessId>,
+  store?: HeadlessEnhancedStore,
   headlessReducerManager?: HeadlessReducerManager,
   httpManager?: HttpManager
 ): AnswersHeadless {


### PR DESCRIPTION
Using react 18 with the current answers-headless would result in peer dependency incompatibility issues with redux. Upgrade redux-toolkit to 1.8.1 ([release notes](https://github.com/reduxjs/redux-toolkit/releases/tag/v1.8.1)). [Support react version](https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/package.json#L108) at this time:  `"react": "^16.9.0 || ^17.0.0 || ^18"`
<img width="780" alt="Screen Shot 2022-05-18 at 3 51 45 PM" src="https://user-images.githubusercontent.com/36055303/169144269-9cd54738-98ed-4f47-bde4-ae1fa4c01406.png">
This upgrade will result in an error from store.dispatch call, specifically some of redux-toolkit's 1.8 changes to middleware dispatch types may lead to the dispatch function to be typed as never in TypeScript.
<img width="1002" alt="Screen Shot 2022-05-18 at 3 54 53 PM" src="https://user-images.githubusercontent.com/36055303/169144773-57158e82-8ccb-4dec-8388-a5903309b58b.png">
This can be resolve by specifying the third generic type for Middleware in EnhancedStore interface, which is:
`export interface EnhancedStore<S = any, A extends Action = AnyAction, M extends Middlewares<S> = Middlewares<S>> extends Store<S, A>`

From [documentation](https://github.com/reduxjs/redux-thunk#redux-toolkit) on redux-thunk github page, since we are using redux-toolkit already, there's no need to install redux-thunk separately so that's removed from package.json's deps.

Note: will release an alpha version containing this change to use in answer-headless-react's alpha version as well.

J=SLAP-2095
TEST=manual

see that `npm run build` was successful. When used locally with answers-headless-react and answers-react-components, hooked to the test-site with React 18, the pages work as expected.